### PR TITLE
Rn/roulette

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ fn main() {
 
         // Lights
         Object {
-            shape: Box::new(Sphere{ center: Vector3::new(0.0, -500.0, -0.0), radius: 150.0 }),
+            shape: Box::new(Sphere{ center: Vector3::new(0.0, -450.0, -0.0), radius: 150.0 }),
             material: Box::new(Lambertian::new(Colour::rgb(0.0, 0.0, 0.0), Colour::rgb(7.0, 7.0, 7.0))),
         },
         ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 mod paths;
 
+use std::time::Instant;
+
 use crate::paths::Camera;
 use crate::paths::colour::Colour;
 use crate::paths::material::{Lambertian, Mirror};
@@ -94,12 +96,14 @@ fn main() {
 
     let mut num_samples = 0;
 
+    let start_time = Instant::now();
+
     while is_running {
         renderer.trace_full_pass();
         let image = renderer.render();
 
         num_samples += 1;
-        println!("Num samples: {:?}", num_samples);
+        println!("[{:.1?}] Num samples: {:?}", start_time.elapsed(), num_samples);
 
         for ix in 0 .. image.pixels.len() {
             let colour = image.pixels[ix];

--- a/src/paths/colour.rs
+++ b/src/paths/colour.rs
@@ -35,6 +35,11 @@ impl Colour {
             )
     }
 
+    pub fn max(&self) -> f64 {
+        let w = if self.r > self.g { self.r } else { self.g };
+        if w > self.b { w } else { self.b }
+    }
+
     fn component_to_byte(x: f64) -> u8 {
         let rounded = (x * 256.0) as i16;
         if rounded >= 256 {

--- a/src/paths/vector.rs
+++ b/src/paths/vector.rs
@@ -20,6 +20,11 @@ impl Vector3 {
         self.dot(*self)
     }
 
+    pub fn max(&self) -> f64 {
+        let w = if self.x > self.y { self.x } else { self.y };
+        if w > self.z { w } else { self.z }
+    }
+
     pub fn normed(&self) -> Vector3 {
         (*self) / self.magnitude().sqrt()
     }


### PR DESCRIPTION
5 minutes, 1420 samples
Almost doubles the number of samples we managed in 5 minutes compared to #1 

![image](https://user-images.githubusercontent.com/3620166/53811777-7234f780-3f9d-11e9-9060-946d76be27f7.png)
