### PR TITLE
Realistic camera

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use crate::paths::vector::Vector3;
 use sdl2::{event, pixels};
 use sdl2::keyboard::Keycode;
 
-const WIDTH: u32 = 640;
+const WIDTH: u32 = 720;
 const HEIGHT: u32 = 480;
 const SCALE: u32 = 1;
 
@@ -41,32 +41,42 @@ fn main() {
     };
 
     let mut camera = Camera::new(WIDTH, HEIGHT);
+    // All distances in m;
     camera.location.x = 0.0;
-    camera.location.y = -600.0;
-    camera.location.z = -400.0;
-    camera.sensor_width = 32.0;
-    camera.sensor_height = 24.0;
-    camera.focal_length = 9.86;
-    camera.distance_from_lens = 10.0;
-    camera.lens_radius = 20.0;
+    camera.location.y = -2.0;
+    camera.location.z = -10.0;
 
-    let mut yaw: f64 = -0.1;
-    let mut pitch: f64 = -0.1;
-    let mut roll: f64 = -0.1;
+    // Full frame DSLR sensor.
+    camera.sensor_width = 0.036;
+    camera.sensor_height = 0.024;
+
+    // 50mm lens.
+    camera.focal_length = 0.05;
+
+    // Focus on back sphere
+    let focus_distance = (2f64 * 2f64 + 40f64 * 40f64).sqrt();
+    camera.distance_from_lens = (camera.focal_length * focus_distance) / (focus_distance - camera.focal_length);
+
+    // f stop
+    camera.aperture = 0.8;
+
+    let mut yaw: f64 = -0.0;
+    let mut pitch: f64 = -0.0;
+    let mut roll: f64 = -0.0;
     camera.set_orientation(yaw, pitch, roll);
 
     let objects = vec![
         // Objects
         Object {
-            shape: Box::new(Sphere{ center: Vector3::new(0.0, -100.0, 0.0), radius: 100.0 }),
+            shape: Box::new(Sphere{ center: Vector3::new(0.0, -2.0, 30.0), radius: 2.0 }),
             material: Box::new(Mirror{}),
         },
         Object {
-            shape: Box::new(Sphere{ center: Vector3::new(330.0, -200.0, -0.0), radius: 200.0 }),
+            shape: Box::new(Sphere{ center: Vector3::new(3.0, -2.0, 0.0), radius: 2.0 }),
             material: Box::new(Gloss::new(Colour::rgb(0.8, 0.3, 0.3), 1.5)),
         },
         Object {
-            shape: Box::new(Sphere{ center: Vector3::new(-330.0, -200.0, -0.0), radius: 200.0 }),
+            shape: Box::new(Sphere{ center: Vector3::new(-3.0, -2.0, 0.0), radius: 2.0 }),
             material: Box::new(Gloss::new(Colour::rgb(0.0, 0.3, 0.8), 2.0)),
         },
 
@@ -123,19 +133,21 @@ fn main() {
                        renderer.reset();
                        num_samples = 0;
                    },
-                   Some(Keycode::O) => yaw -= 0.2,
-                   Some(Keycode::U) => yaw += 0.2,
-                   Some(Keycode::I) => pitch -= 0.2,
-                   Some(Keycode::K) => pitch += 0.2,
-                   Some(Keycode::J) => roll -= 0.2,
-                   Some(Keycode::L) => roll += 0.2,
+                   Some(Keycode::O) => yaw -= 0.1,
+                   Some(Keycode::U) => yaw += 0.1,
+                   Some(Keycode::I) => pitch -= 0.1,
+                   Some(Keycode::K) => pitch += 0.1,
+                   Some(Keycode::J) => roll -= 0.1,
+                   Some(Keycode::L) => roll += 0.1,
+                   Some(Keycode::W) => renderer.camera.distance_from_lens += 0.00001,
+                   Some(Keycode::Q) => renderer.camera.distance_from_lens -= 0.00001,
                    _ => (),
                 },
                 _ => (),
             }
             renderer.camera.set_orientation(yaw, pitch, roll);
             println!("Yaw: {:.1}, Pitch: {:.1}, Roll: {:.1}", yaw, pitch, roll);
-            println!("F: {:.1}, V: {:.1}, R: {:.1}", renderer.camera.focal_length, renderer.camera.distance_from_lens, renderer.camera.lens_radius);
+            println!("F: {:.1}, V: {:.1}, A: {:.1}", renderer.camera.focal_length, renderer.camera.distance_from_lens, renderer.camera.aperture);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,10 +42,18 @@ fn main() {
 
     let mut camera = Camera::new(WIDTH, HEIGHT);
     camera.location.x = 0.0;
-    camera.location.y = -400.0;
-    camera.location.z = -600.0;
-    camera.focal_length = 400.0;
-    camera.set_orientation(0.0, -0.1, -0.4);
+    camera.location.y = -600.0;
+    camera.location.z = -400.0;
+    camera.sensor_width = 32.0;
+    camera.sensor_height = 24.0;
+    camera.focal_length = 9.86;
+    camera.distance_from_lens = 10.0;
+    camera.lens_radius = 20.0;
+
+    let mut yaw: f64 = -0.1;
+    let mut pitch: f64 = -0.1;
+    let mut roll: f64 = -0.1;
+    camera.set_orientation(yaw, pitch, roll);
 
     let objects = vec![
         // Objects
@@ -91,7 +99,7 @@ fn main() {
         let image = renderer.render();
 
         num_samples += 1;
-        println!("[{:.1?}] Num samples: {:?}", start_time.elapsed(), num_samples);
+        //println!("[{:.1?}] Num samples: {:?}", start_time.elapsed(), num_samples);
 
         for ix in 0 .. image.pixels.len() {
             let colour = image.pixels[ix];
@@ -110,10 +118,24 @@ fn main() {
             match e {
                 event::Event::KeyDown { keycode, .. } => match keycode {
                    Some(Keycode::Escape) => is_running = false,
+                   Some(Keycode::Return) => {
+                       println!("Resetting render");
+                       renderer.reset();
+                       num_samples = 0;
+                   },
+                   Some(Keycode::O) => yaw -= 0.2,
+                   Some(Keycode::U) => yaw += 0.2,
+                   Some(Keycode::I) => pitch -= 0.2,
+                   Some(Keycode::K) => pitch += 0.2,
+                   Some(Keycode::J) => roll -= 0.2,
+                   Some(Keycode::L) => roll += 0.2,
                    _ => (),
                 },
                 _ => (),
             }
+            renderer.camera.set_orientation(yaw, pitch, roll);
+            println!("Yaw: {:.1}, Pitch: {:.1}, Roll: {:.1}", yaw, pitch, roll);
+            println!("F: {:.1}, V: {:.1}, R: {:.1}", renderer.camera.focal_length, renderer.camera.distance_from_lens, renderer.camera.lens_radius);
         }
     }
 }

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -45,59 +45,67 @@ pub struct Image {
 pub struct Camera {
     pub location: Vector3,  // Center of camera sensor.
     pub focal_length: f64,
-    pub yaw: f64,  // Radians
-    pub pitch: f64,    // Radians
-    pub roll: f64,   // Radians
-    x_vec: Vector3,
-    y_vec: Vector3,
-    direction: Vector3,
+    pub lens_radius: f64,
+    pub distance_from_lens: f64,
+    rot: Matrix3,
+    pub sensor_width: f64,
+    pub sensor_height: f64,
     pub width: u32,
     pub height: u32,
 }
 
 impl Camera {
     pub fn new(width: u32, height: u32) -> Camera {
-        let mut camera = Camera {
+        let camera = Camera {
             location: Vector3::new(0.0, 0.0, 0.0),
-            focal_length: 10.0,
-            yaw: 0.0,
-            pitch: 0.0,
-            roll: 0.0,
-            x_vec: Vector3::new(0.0, 0.0, 0.0),
-            y_vec: Vector3::new(0.0, 0.0, 0.0),
-            direction: Vector3::new(0.0, 0.0, 0.0),
+            focal_length: 1000.0,
+            lens_radius: 1000.0,
+            distance_from_lens: 100.0,
+            rot: Matrix3::zero(),
+            sensor_width: width as f64,
+            sensor_height: height as f64,
             width,
             height,
         };
-        camera.recompute();
         camera
     }
 
     pub fn get_ray_for_pixel(&self, x: u32, y: u32) -> Ray {
         let mut rng = rand::thread_rng();
+
+        // We'll compute the outbound ray first in lens-space where the centre of 
+        // the lens is at the origin.
+        // Then transform into world space.
+        // This makes the refraction through the lens trivially computable.
         let x_offset: f64 = (x as f64) - ((self.width as f64) / 2.0) + rng.gen::<f64>();
         let y_offset: f64 = (y as f64) - ((self.height as f64) / 2.0) + rng.gen::<f64>();
 
-        Ray { 
-            origin: self.location,
-            direction: ((self.direction * self.focal_length) + (self.x_vec * x_offset) + (self.y_vec * y_offset)).normed(),
-        }
+        // Calculate distance to focal plane.
+        let f = self.focal_length;
+        let v = self.distance_from_lens;
+        let p = (f * v) / (v - f);
+
+        // k = point on sensor
+        let x_scale = self.sensor_width / (self.width as f64);
+        let y_scale = self.sensor_height / (self.height as f64);
+        let k = Vector3::new(x_offset * x_scale, y_offset * y_scale, -self.distance_from_lens);
+
+        // l = point on lens
+        let theta = rng.gen::<f64>();
+        let r = rng.gen::<f64>() * self.lens_radius;
+        let l = Vector3::new(r * theta.cos(), r * theta.sin(), 0.0);
+
+        // this equation for ray direction precomputed by hand to collapse all the terms that go away.
+        let dir = ((k * (p/v)) + l) * -1;
+
+        // Now transform into world space.
+        let origin = self.rot.clone() * l + self.location;
+        let direction = (self.rot.clone() * dir).normed();
+
+        Ray { origin, direction }
     }
 
     pub fn set_orientation(&mut self, yaw: f64, pitch: f64, roll: f64) {
-        self.yaw = yaw;
-        self.pitch = pitch;
-        self.roll = roll;
-        self.recompute();
-    }
-
-    fn recompute(&mut self) {
-        let i = Vector3::new(1.0, 0.0, 0.0);
-        let j = Vector3::new(0.0, 1.0, 0.0);
-        let k = Vector3::new(0.0, 0.0, 1.0);
-        let rot = Matrix3::rotation(self.yaw, self.pitch, self.roll);
-        self.x_vec = rot.clone() * i;
-        self.y_vec = rot.clone() * j;
-        self.direction = rot.clone() * k;
+        self.rot = Matrix3::rotation(yaw, pitch, roll);
     }
 }

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -45,8 +45,8 @@ pub struct Image {
 pub struct Camera {
     pub location: Vector3,  // Center of camera sensor.
     pub focal_length: f64,
-    pub lens_radius: f64,
     pub distance_from_lens: f64,
+    pub aperture: f64,
     rot: Matrix3,
     pub sensor_width: f64,
     pub sensor_height: f64,
@@ -58,9 +58,9 @@ impl Camera {
     pub fn new(width: u32, height: u32) -> Camera {
         let camera = Camera {
             location: Vector3::new(0.0, 0.0, 0.0),
-            focal_length: 1000.0,
-            lens_radius: 1000.0,
-            distance_from_lens: 100.0,
+            focal_length: 9.86,
+            distance_from_lens: 10.0,
+            aperture: 2.0,
             rot: Matrix3::zero(),
             sensor_width: width as f64,
             sensor_height: height as f64,
@@ -92,7 +92,8 @@ impl Camera {
 
         // l = point on lens
         let theta = rng.gen::<f64>();
-        let r = rng.gen::<f64>() * self.lens_radius;
+        let aperture_radius = f / self.aperture;
+        let r = rng.gen::<f64>() * aperture_radius;
         let l = Vector3::new(r * theta.cos(), r * theta.sin(), 0.0);
 
         // this equation for ray direction precomputed by hand to collapse all the terms that go away.

--- a/src/paths/pixels.rs
+++ b/src/paths/pixels.rs
@@ -44,7 +44,8 @@ impl Estimator {
     }
 
     pub fn update_pixel(&mut self, x: usize, y: usize, colour: Colour) {
-        self.means.update(x + (y * self.width), colour);
+        let reflected_y = self.height - y - 1;
+        self.means.update(x + (reflected_y * self.width), colour);
     }
 
     pub fn choose_pixel(&self) -> (usize, usize) {

--- a/src/paths/renderer.rs
+++ b/src/paths/renderer.rs
@@ -11,7 +11,7 @@ use crate::paths::scene::Scene;
 
 pub struct Renderer {
     scene: Scene,
-    camera: Camera,
+    pub camera: Camera,
     estimator: Estimator,
     pool: ThreadPool,
 }
@@ -57,6 +57,10 @@ impl Renderer {
             let colour = Renderer::trace_ray(&self.scene, ray, 0);
             self.estimator.update_pixel(x as usize, y as usize, colour);
         }
+    }
+
+    pub fn reset(&mut self) {
+        self.estimator = Estimator::new(self.camera.width as usize, self.camera.height as usize);
     }
 
     fn trace_ray(scene: &Scene, ray: Ray, depth: u32) -> Colour {

--- a/src/paths/renderer.rs
+++ b/src/paths/renderer.rs
@@ -87,7 +87,7 @@ impl Renderer {
         }
 
         let new_ray = Ray{
-            origin: collision.location + collision.normal,  // Add the normal as a hack so it doesn't collide with the same object again.
+            origin: collision.location + collision.normal * 0.001,  // Add the normal as a hack so it doesn't collide with the same object again.
             direction: material.sample_pdf(ray.direction * -1, collision.normal),
         };
 


### PR DESCRIPTION
This simulates a real lens in front of the camera, meaning we can get nice things like depth-of-field effects.

I spent a _long_ time faffing about with parameters until I decided it would just be best to take some from a real-life camera, and then it just worked!

The only thing different between the two below images is the distance between the camera sensor and the lens.

Focused on front spheres:
![image](https://user-images.githubusercontent.com/3620166/53969834-d7731f00-413c-11e9-8fa5-410dd1a32c6d.png)

Focused on back sphere:
![image](https://user-images.githubusercontent.com/3620166/53969889-f40f5700-413c-11e9-989b-93834966342f.png)
