### PR TITLE
Correlated multi jittered sampling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,10 +42,11 @@ fn main() {
     };
 
     let mut camera = Camera::new(WIDTH, HEIGHT, Box::new(CorrelatedMultiJitteredSampler::new(42, 8, 8)));
+   
     // All distances in m;
     camera.location.x = 0.0;
-    camera.location.y = -2.0;
-    camera.location.z = -10.0;
+    camera.location.y = -0.01;
+    camera.location.z = -15.0;
 
     // Full frame DSLR sensor.
     camera.sensor_width = 0.036;
@@ -55,11 +56,11 @@ fn main() {
     camera.focal_length = 0.05;
 
     // Focus on back sphere
-    let focus_distance = (2f64 * 2f64 + 40f64 * 40f64).sqrt();
+    let focus_distance = 1.0;//(2f64 * 2f64 + 40f64 * 40f64).sqrt();
     camera.distance_from_lens = (camera.focal_length * focus_distance) / (focus_distance - camera.focal_length);
 
     // f stop
-    camera.aperture = 0.8;
+    camera.aperture = 2.0;
 
     let mut yaw: f64 = -0.0;
     let mut pitch: f64 = -0.0;
@@ -79,6 +80,11 @@ fn main() {
         Object {
             shape: Box::new(Sphere{ center: Vector3::new(-3.0, -2.0, 0.0), radius: 2.0 }),
             material: Box::new(Gloss::new(Colour::rgb(0.0, 0.3, 0.8), 2.0)),
+        },
+
+        Object {
+            shape: Box::new(Sphere{ center: Vector3::new(-0.1, -0.1, -14.00), radius: 0.1 }),
+            material: Box::new(Lambertian::new(Colour::rgb(0.3, 0.8, 0.3), Colour::BLACK)),
         },
 
         // Ground
@@ -110,7 +116,7 @@ fn main() {
         let image = renderer.render();
 
         num_samples += 1;
-        //println!("[{:.1?}] Num samples: {:?}", start_time.elapsed(), num_samples);
+        println!("[{:.1?}] Num samples: {:?}", start_time.elapsed(), num_samples);
 
         for ix in 0 .. image.pixels.len() {
             let colour = image.pixels[ix];

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use crate::paths::Camera;
 use crate::paths::colour::Colour;
 use crate::paths::material::{Lambertian, Mirror, Gloss};
 use crate::paths::scene::{GradientSky, Object, Scene, Sphere};
-use crate::paths::sampling::UniformSampler;
+use crate::paths::sampling::{CorrelatedMultiJitteredSampler, UniformSampler};
 use crate::paths::renderer::Renderer;
 use crate::paths::vector::Vector3;
 
@@ -41,7 +41,7 @@ fn main() {
         Ok(t) => t,
     };
 
-    let mut camera = Camera::new(WIDTH, HEIGHT, Box::new(UniformSampler{}));
+    let mut camera = Camera::new(WIDTH, HEIGHT, Box::new(CorrelatedMultiJitteredSampler::new(42, 8, 8)));
     // All distances in m;
     camera.location.x = 0.0;
     camera.location.y = -2.0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use crate::paths::Camera;
 use crate::paths::colour::Colour;
 use crate::paths::material::{Lambertian, Mirror, Gloss};
 use crate::paths::scene::{GradientSky, Object, Scene, Sphere};
+use crate::paths::sampling::UniformSampler;
 use crate::paths::renderer::Renderer;
 use crate::paths::vector::Vector3;
 
@@ -40,7 +41,7 @@ fn main() {
         Ok(t) => t,
     };
 
-    let mut camera = Camera::new(WIDTH, HEIGHT);
+    let mut camera = Camera::new(WIDTH, HEIGHT, Box::new(UniformSampler{}));
     // All distances in m;
     camera.location.x = 0.0;
     camera.location.y = -2.0;

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -83,6 +83,7 @@ impl Camera {
     }
 
     pub fn init_bundle(&mut self) {
+        self.sampler.next();
         let (jx, jy) = self.sampler.sample_square();
         self.bundle_offsets = (jx, jy);
 

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -83,7 +83,8 @@ impl Camera {
     }
 
     pub fn init_bundle(&mut self) {
-        self.bundle_offsets = self.sampler.sample_square();
+        let (jx, jy) = self.sampler.sample_square();
+        self.bundle_offsets = (jx, jy);
 
         let aperture_radius = self.focal_length / self.aperture;
         let (lens_x, lens_y) = self.sampler.sample_disk();

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -3,6 +3,7 @@ pub mod material;
 pub mod matrix;
 pub mod pixels;
 pub mod renderer;
+pub mod sampling;
 pub mod scene;
 pub mod vector;
 
@@ -13,6 +14,7 @@ use rand::Rng;
 
 use self::colour::Colour;
 use self::matrix::Matrix3;
+use self::sampling::Sampler;
 use self::vector::Vector3;
 
 #[derive(Clone, Copy, Debug)]
@@ -52,10 +54,11 @@ pub struct Camera {
     pub sensor_height: f64,
     pub width: u32,
     pub height: u32,
+    sampler: Box<dyn Sampler>,
 }
 
 impl Camera {
-    pub fn new(width: u32, height: u32) -> Camera {
+    pub fn new(width: u32, height: u32, sampler: Box<dyn Sampler>) -> Camera {
         let camera = Camera {
             location: Vector3::new(0.0, 0.0, 0.0),
             focal_length: 9.86,
@@ -66,19 +69,16 @@ impl Camera {
             sensor_height: height as f64,
             width,
             height,
+            sampler,
         };
         camera
     }
 
-    pub fn get_ray_for_pixel(&self, x: u32, y: u32) -> Ray {
-        let mut rng = rand::thread_rng();
-
+    pub fn get_ray_for_pixel(&mut self, x: u32, y: u32) -> Ray {
         // We'll compute the outbound ray first in lens-space where the centre of 
         // the lens is at the origin.
         // Then transform into world space.
         // This makes the refraction through the lens trivially computable.
-        let x_offset: f64 = (x as f64) - ((self.width as f64) / 2.0) + rng.gen::<f64>();
-        let y_offset: f64 = (y as f64) - ((self.height as f64) / 2.0) + rng.gen::<f64>();
 
         // Calculate distance to focal plane.
         let f = self.focal_length;
@@ -86,15 +86,17 @@ impl Camera {
         let p = (f * v) / (v - f);
 
         // k = point on sensor
+        let (x_offset, y_offset) = self.sampler.sample_square();
         let x_scale = self.sensor_width / (self.width as f64);
         let y_scale = self.sensor_height / (self.height as f64);
-        let k = Vector3::new(x_offset * x_scale, y_offset * y_scale, -self.distance_from_lens);
+        let image_x = (x as f64) - (self.width as f64) / 2.0 + x_offset;
+        let image_y = (y as f64) - (self.height as f64) / 2.0 + y_offset;
+        let k = Vector3::new(image_x * x_scale, image_y * y_scale, -self.distance_from_lens);
 
         // l = point on lens
-        let theta = rng.gen::<f64>();
         let aperture_radius = f / self.aperture;
-        let r = rng.gen::<f64>() * aperture_radius;
-        let l = Vector3::new(r * theta.cos(), r * theta.sin(), 0.0);
+        let (lens_x, lens_y) = self.sampler.sample_disk();
+        let l = Vector3::new(lens_x * aperture_radius, lens_y * aperture_radius, 0.0);
 
         // this equation for ray direction precomputed by hand to collapse all the terms that go away.
         let dir = ((k * (p/v)) + l) * -1;

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -55,11 +55,15 @@ pub struct Camera {
     pub width: u32,
     pub height: u32,
     sampler: Box<dyn Sampler>,
+
+    // Current bundle details.
+    bundle_offsets: (f64, f64),
+    bundle_lens_point: Vector3,
 }
 
 impl Camera {
     pub fn new(width: u32, height: u32, sampler: Box<dyn Sampler>) -> Camera {
-        let camera = Camera {
+        let mut camera = Camera {
             location: Vector3::new(0.0, 0.0, 0.0),
             focal_length: 9.86,
             distance_from_lens: 10.0,
@@ -70,8 +74,20 @@ impl Camera {
             width,
             height,
             sampler,
+
+            bundle_offsets: (0.0, 0.0),
+            bundle_lens_point: Vector3::new(0.0, 0.0, 0.0),
         };
+        camera.init_bundle();
         camera
+    }
+
+    pub fn init_bundle(&mut self) {
+        self.bundle_offsets = self.sampler.sample_square();
+
+        let aperture_radius = self.focal_length / self.aperture;
+        let (lens_x, lens_y) = self.sampler.sample_disk();
+        self.bundle_lens_point = Vector3::new(lens_x * aperture_radius, lens_y * aperture_radius, 0.0);
     }
 
     pub fn get_ray_for_pixel(&mut self, x: u32, y: u32) -> Ray {
@@ -86,7 +102,7 @@ impl Camera {
         let p = (f * v) / (v - f);
 
         // k = point on sensor
-        let (x_offset, y_offset) = self.sampler.sample_square();
+        let (x_offset, y_offset) = self.bundle_offsets;
         let x_scale = self.sensor_width / (self.width as f64);
         let y_scale = self.sensor_height / (self.height as f64);
         let image_x = (x as f64) - (self.width as f64) / 2.0 + x_offset;
@@ -94,9 +110,7 @@ impl Camera {
         let k = Vector3::new(image_x * x_scale, image_y * y_scale, -self.distance_from_lens);
 
         // l = point on lens
-        let aperture_radius = f / self.aperture;
-        let (lens_x, lens_y) = self.sampler.sample_disk();
-        let l = Vector3::new(lens_x * aperture_radius, lens_y * aperture_radius, 0.0);
+        let l = self.bundle_lens_point;
 
         // this equation for ray direction precomputed by hand to collapse all the terms that go away.
         let dir = ((k * (p/v)) + l) * -1;

--- a/src/paths/renderer.rs
+++ b/src/paths/renderer.rs
@@ -33,7 +33,7 @@ impl Renderer {
         for x in 0 .. self.camera.width {
             let tx = tx.clone();
             let scene = self.scene.clone();
-            let camera = self.camera.clone();
+            let mut camera = self.camera.clone();
 
             self.pool.execute(move|| {
                 for y in 0 .. camera.height {

--- a/src/paths/renderer.rs
+++ b/src/paths/renderer.rs
@@ -30,6 +30,8 @@ impl Renderer {
     pub fn trace_full_pass(&mut self) {
         let (tx, rx) = channel::<(u32, u32, Colour)>();
 
+        self.camera.init_bundle();
+
         for x in 0 .. self.camera.width {
             let tx = tx.clone();
             let scene = self.scene.clone();

--- a/src/paths/renderer.rs
+++ b/src/paths/renderer.rs
@@ -8,6 +8,7 @@ use crate::paths::{Camera, Image, Ray};
 use crate::paths::colour::{Colour};
 use crate::paths::pixels::Estimator;
 use crate::paths::scene::Scene;
+use crate::paths::vector::Vector3;
 
 pub struct Renderer {
     scene: Scene,
@@ -40,7 +41,8 @@ impl Renderer {
             self.pool.execute(move|| {
                 for y in 0 .. camera.height {
                     let ray = camera.get_ray_for_pixel(x, y);
-                    let colour = Renderer::trace_ray(&scene, ray, 0);
+                    let weight = ray.direction.dot(Vector3::new(0.0, 0.0, 1.0));
+                    let colour = Renderer::trace_ray(&scene, ray, 0) * weight;
                     tx.send((x, y, colour)).expect("can send result back");
                 }
             });
@@ -89,7 +91,7 @@ impl Renderer {
         }
 
         let new_ray = Ray{
-            origin: collision.location + collision.normal * 0.001,  // Add the normal as a hack so it doesn't collide with the same object again.
+            origin: collision.location + collision.normal * 0.0001,  // Add the normal as a hack so it doesn't collide with the same object again.
             direction: material.sample_pdf(ray.direction * -1, collision.normal),
         };
 

--- a/src/paths/sampling.rs
+++ b/src/paths/sampling.rs
@@ -1,0 +1,44 @@
+use rand;
+use rand::Rng;
+
+
+pub trait Sampler : SamplerClone + Send {
+    // Samples the unit square, returning x, y.
+    fn sample_square(&mut self) -> (f64, f64);
+
+    // Samples the unit disk, returning x, y.
+    fn sample_disk(&mut self) -> (f64, f64);
+}
+
+pub trait SamplerClone {
+    fn clone_box(&self) -> Box<Sampler>;
+}
+
+impl <T> SamplerClone for T where T: 'static + Sampler + Clone {
+    fn clone_box(&self) -> Box<Sampler> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<Sampler> {
+    fn clone(&self) -> Box<Sampler> {
+        self.clone_box()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct UniformSampler {}
+
+impl Sampler for UniformSampler {
+    fn sample_square(&mut self) -> (f64, f64) {
+        let mut rng = rand::thread_rng();
+        (rng.gen(), rng.gen())
+    }
+
+    fn sample_disk(&mut self) -> (f64, f64) {
+        let mut rng = rand::thread_rng();
+        let r = rng.gen::<f64>();
+        let theta = rng.gen::<f64>();
+        (r * theta.cos(), r * theta.sin())
+    }
+}

--- a/src/paths/sampling.rs
+++ b/src/paths/sampling.rs
@@ -1,3 +1,5 @@
+use std::f64::consts::PI;
+
 use rand;
 use rand::Rng;
 
@@ -39,6 +41,91 @@ impl Sampler for UniformSampler {
         let mut rng = rand::thread_rng();
         let r = rng.gen::<f64>();
         let theta = rng.gen::<f64>();
+        (r * theta.cos(), r * theta.sin())
+    }
+}
+
+// This is the algorithm developed by Pixar for their RenderMan engine.
+// All the random looking equations are part of the hash function they developed.
+// See https://graphics.pixar.com/library/MultiJitteredSampling/paper.pdf for details.
+#[derive(Clone, Debug)]
+pub struct CorrelatedMultiJitteredSampler {
+    p: u32,
+    m: u32,
+    n: u32,
+    s: u32,
+}
+
+impl CorrelatedMultiJitteredSampler {
+    pub fn new(p: u32, m: u32, n: u32) -> CorrelatedMultiJitteredSampler {
+        CorrelatedMultiJitteredSampler{ p, m, n, s: 0 }
+    }
+
+    fn permute(mut i: u32, l: u32, p: u32) -> u32 {
+        let mut w = l - 1;
+        w |= w >> 1;
+        w |= w >> 2;
+        w |= w >> 4;
+        w |= w >> 8;
+        w |= w >> 16;
+        while i > l {
+            i ^= p;             i *= 0xe170_893d;
+            i ^= p       >> 16;
+            i ^= (i & w) >> 4;
+            i ^= p       >> 8;  i *= 0x0929_eb3f;
+            i ^= p       >> 23;
+            i ^= (i & w) >> 1;  i *= 1 | p >> 27;
+                                i *= 0x6935_fa69;
+            i ^= (i & w) >> 11; i *= 0x74dc_b303;
+            i ^= (i & w) >> 2;  i *= 0x9e50_1cc3;
+            i ^= (i & w) >> 2;  i *= 0xc860_a3df;
+            i &= w;
+            i ^= i       >> 5;
+        }
+
+        (i + p) % l
+    }
+
+    fn rand_float(mut i: u32, p: u32) -> f64 {
+        i ^= p;
+        i ^= i >> 17;
+        i ^= i >> 10; i *= 0xb365_34e5;
+        i ^= i >> 12;
+        i ^= i >> 21; i *= 0x93fc_4795;
+        i ^= 0xdf6e_307f;
+        i ^= i >> 17; i *= 1 | p >> 18;
+        (i as f64) * (1.0 / 4_294_967_808.0)
+    }
+
+    // s = sample index
+    // m, n = sample dimensions (m x n = N = number of samples total)
+    // p = pattern index (like a seed)
+    fn cmj(s: u32, m: u32, n: u32, p: u32) -> (f64, f64) {
+        let sx: f64 = CorrelatedMultiJitteredSampler::permute(s % m, m, p * 0xa511_e9b3) as f64;
+        let sy: f64 = CorrelatedMultiJitteredSampler::permute(s / m, n, p * 0x63d8_3595) as f64;
+        let jx: f64 = CorrelatedMultiJitteredSampler::rand_float(s, p * 0xa399_d265);
+        let jy: f64 = CorrelatedMultiJitteredSampler::rand_float(s, p * 0x711a_d6a5);
+        let x: f64 = (((s % m) as f64) + (sy + jx) / (n as f64)) / (m as f64);
+        let y: f64 = (((s / m) as f64) + (sx + jy) / (m as f64)) / (n as f64);
+        (x, y)
+    }
+}
+
+impl Sampler for CorrelatedMultiJitteredSampler {
+    fn sample_square(&mut self) -> (f64, f64) {
+        let sample = CorrelatedMultiJitteredSampler::cmj(self.s, self.m, self.n, self.p);
+        self.n += 1;
+        sample
+    }
+
+    fn sample_disk(&mut self) -> (f64, f64) {
+        // Sample the square and then map to the disk.
+        // Only works if m ~= n
+        let (x, y) = CorrelatedMultiJitteredSampler::cmj(self.s, self.m, self.n, self.p);
+        self.n += 1;
+
+        let theta = 2.0 * PI * x;
+        let r = y.sqrt();
         (r * theta.cos(), r * theta.sin())
     }
 }

--- a/src/paths/sampling.rs
+++ b/src/paths/sampling.rs
@@ -101,8 +101,9 @@ impl CorrelatedMultiJitteredSampler {
     // m, n = sample dimensions (m x n = N = number of samples total)
     // p = pattern index (like a seed)
     fn cmj(s: u32, m: u32, n: u32, p: u32) -> (f64, f64) {
-        let sx: f64 = CorrelatedMultiJitteredSampler::permute(s % m, m, p * 0xa511_e9b3) as f64;
-        let sy: f64 = CorrelatedMultiJitteredSampler::permute(s / m, n, p * 0x63d8_3595) as f64;
+        let ps: u32 = CorrelatedMultiJitteredSampler::permute(s, m*n, p * 0xa73b_d290);
+        let sx: f64 = CorrelatedMultiJitteredSampler::permute(ps % m, m, p * 0xa511_e9b3) as f64;
+        let sy: f64 = CorrelatedMultiJitteredSampler::permute(ps / m, n, p * 0x63d8_3595) as f64;
         let jx: f64 = CorrelatedMultiJitteredSampler::rand_float(s, p * 0xa399_d265);
         let jy: f64 = CorrelatedMultiJitteredSampler::rand_float(s, p * 0x711a_d6a5);
         let x: f64 = (((s % m) as f64) + (sy + jx) / (n as f64)) / (m as f64);
@@ -114,15 +115,14 @@ impl CorrelatedMultiJitteredSampler {
 impl Sampler for CorrelatedMultiJitteredSampler {
     fn sample_square(&mut self) -> (f64, f64) {
         let sample = CorrelatedMultiJitteredSampler::cmj(self.s, self.m, self.n, self.p);
-        self.n += 1;
         sample
     }
 
     fn sample_disk(&mut self) -> (f64, f64) {
         // Sample the square and then map to the disk.
         // Only works if m ~= n
-        let (x, y) = CorrelatedMultiJitteredSampler::cmj(self.s, self.m, self.n, self.p);
-        self.n += 1;
+        let (x, y) = CorrelatedMultiJitteredSampler::cmj(self.s, self.m, self.n, self.p + 1);
+        self.s += 1;
 
         let theta = 2.0 * PI * x;
         let r = y.sqrt();


### PR DESCRIPTION
Generalize random sampling logic.
Add a sampler based on the algorithm described in https://graphics.pixar.com/library/MultiJitteredSampling/paper.pdf

This new sampler appears to produce a much wider bokeh than the uniform sampler.  I'm going to assume that's something to do with the distribution, CMJ produces more points near the edge of the lens.   I thought weighting the rays would compensate for that, but it doesn't.

Needs investigation, but not going to block merging this for now.

Example [1 minute, 440 samples]:
![image](https://user-images.githubusercontent.com/3620166/54071839-a5d19380-42b5-11e9-991b-79a161de34e8.png)
