### PR TITLE
Fix artifacts in mesh rendering

### DIFF
--- a/src/geom.rs
+++ b/src/geom.rs
@@ -171,12 +171,15 @@ impl BoundedVolume for Triangle {
         let by = area_pca / area_abc;
         let bz = 1.0 - bx - by;
 
-        let smooth_normal = an * bx + bn * by + cn * bz;
+        let mut smooth_normal = an * bx + bn * by + cn * bz;
 
-        // If the smoothed face of the triangle curves away from the ray then we shouldn't have hit
-        // it.
+        // If the smoothed face of the triangle curves away from the ray then scale it back so it
+        // barely doesn't.
         if smooth_normal.dot(ray.direction) * cos_theta < 0.0 {
-            return None;
+            let epsilon = 0.05;  // Chosen experimentally.
+            let cos_alpha = smooth_normal.dot(ray.direction);
+            let scale = (cos_alpha - epsilon) / (cos_theta + cos_alpha);
+            smooth_normal = (n * scale + smooth_normal * (1.0 - scale)).normed();
         }
         
         if bx < 0.0 || by < 0.0 || bz < 0.0 {

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -147,10 +147,10 @@ impl BoundedVolume for Triangle {
         let bn = self.vertex_normals[1];
         let cn = self.vertex_normals[2];
 
+        let cos_theta = n.dot(ray.direction);
+
         // d = constant term of triangle plane
         let d = n.dot(a);
-
-        let cos_theta = n.dot(ray.direction);
 
         // t = distance along ray of intersection with plane
         let t = (d - n.dot(ray.origin)) / cos_theta;
@@ -182,7 +182,9 @@ impl BoundedVolume for Triangle {
         if bx < 0.0 || by < 0.0 || bz < 0.0 {
             None
         } else {
-            Some(Collision{ distance: t, location: p, normal: smooth_normal })
+            // Flip the normal if we're hitting the triangle from the back;
+            let back_side_multiplier = if cos_theta > 0.0 { -1.0 } else { 1.0 };
+            Some(Collision{ distance: t, location: p, normal: smooth_normal * back_side_multiplier })
         }
     }
 

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -150,8 +150,10 @@ impl BoundedVolume for Triangle {
         // d = constant term of triangle plane
         let d = n.dot(a);
 
+        let cos_theta = n.dot(ray.direction);
+
         // t = distance along ray of intersection with plane
-        let t = (d - n.dot(ray.origin)) / (n.dot(ray.direction));
+        let t = (d - n.dot(ray.origin)) / cos_theta;
 
         if t.is_nan() || t < 0.0 {
             return None;
@@ -170,6 +172,12 @@ impl BoundedVolume for Triangle {
         let bz = 1.0 - bx - by;
 
         let smooth_normal = an * bx + bn * by + cn * bz;
+
+        // If the smoothed face of the triangle curves away from the ray then we shouldn't have hit
+        // it.
+        if smooth_normal.dot(ray.direction) * cos_theta < 0.0 {
+            return None;
+        }
         
         if bx < 0.0 || by < 0.0 || bz < 0.0 {
             None

--- a/src/material.rs
+++ b/src/material.rs
@@ -133,6 +133,7 @@ impl Gloss {
 impl Material for Gloss {
     fn weight_pdf(&self, vec_out: Vector3, normal: Vector3) -> Colour {
         let cos_theta = vec_out.dot(normal);
+
         let r0 = self.fresnel_r0;
         let r = r0 + (1.0 - r0) * (1.0 - cos_theta).powf(5.0);
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -75,8 +75,8 @@ impl Renderer {
         let reflectance = material.weight_pdf(ray.direction * -1, collision.normal);
 
         // Chance for the material to eat the ray.
-        let absorption_chance = reflectance.max();
-        if rand::thread_rng().gen::<f64>() > absorption_chance {
+        let survival_chance = if depth >= 2 { reflectance.max() } else { 1.0 };
+        if rand::thread_rng().gen::<f64>() > survival_chance {
             return emittance;
         }
 
@@ -87,6 +87,6 @@ impl Renderer {
 
         let incoming: Colour = Renderer::trace_ray(scene, new_ray, depth + 1);
 
-        return emittance + (reflectance * incoming / absorption_chance);
+        return emittance + (reflectance * incoming / survival_chance);
     }
 }


### PR DESCRIPTION
1. Make triangles two-sided.
This fixes the weird colours inside the teapot.  But might cause problems when we implement translucency.  Keep eyes peeled.

2. Clamp smooth surface normals so they never cause rays to reflect into the object.
This causes imperceptibly unrealistic very close to the edges of objects.  But is basically unnoticeable compared to the black artifacts we got before.

3. Fix a bug in the ray/BVH collision code which could cause the ray to hit the wrong triangle in certain circumstances.
Explicitly, previously we always assumed that once we hit a certain AABB, the closest triangle collision must be inside that AABB.
This is not always true.  It's possible to collide with the AABB for triangle X first, but actually collide with triangle Y first.
This fixed the major rendering issues where the handle connects with the body of the teapot.

Fixed teapot:
![image](https://user-images.githubusercontent.com/3620166/54364159-a603d180-46af-11e9-973c-cbab9fac9685.png)
