### PR TITLE
Performance tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ serde_yaml = "0.8"
 
 [profile.dev]
 opt-level = 3
+
+[profile.release]
+debug = true

--- a/src/bvh.rs
+++ b/src/bvh.rs
@@ -98,7 +98,7 @@ pub struct BVH<T> {
 
 impl <T : BoundedVolume> BVH<T> {
     pub fn find_intersection(&self, ray: Ray) -> Option<(Collision, &T)> {
-        let mut q: BinaryHeap<SearchNode<T>> = BinaryHeap::new();
+        let mut q: BinaryHeap<SearchNode<T>> = BinaryHeap::with_capacity(100);
 
         if let Some(distance) = ray_box_collide(&ray, &self.root.aabb()) {
             q.push(SearchNode{ node: &self.root, distance });
@@ -407,7 +407,7 @@ fn get_bit(mc: u64, bit: u16) -> bool {
 
 #[cfg(test)]
 mod test {
-    use crate::paths::bvh;
+    use crate::bvh;
 
     #[test]
     fn test_morton_code() {

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -51,33 +51,61 @@ pub trait BoundedVolume {
     fn intersect(&self, ray: Ray) -> Option<Collision>;
 }
 
-pub trait Shape : BoundedVolume + ShapeClone + Send + Sync {}
-
-impl <T : 'static + BoundedVolume + Clone + Send + Sync> Shape for T {}
-
-pub trait ShapeClone {
-    fn clone_box(&self) -> Box<dyn Shape>;
+#[derive(Clone, Copy, Debug)]
+pub enum Shape {
+    Sphere(SphereShape),
+    Triangle(TriangleShape),
 }
 
-impl <T> ShapeClone for T where T: 'static + Shape + Clone {
-    fn clone_box(&self) -> Box<dyn Shape> {
-        Box::new(self.clone())
+impl Shape {
+    pub fn sphere(center: Vector3, radius: f64) -> Shape {
+        Shape::Sphere(SphereShape{ center, radius })
+    }
+
+    pub fn triangle(vertices: [Vector3; 3], surface_normal: Vector3, vertex_normals: [Vector3; 3]) -> Shape {
+        Shape::Triangle(TriangleShape{ vertices, surface_normal, vertex_normals })
+    }
+
+    pub fn transform(&self, translation: Vector3, rotation: Matrix3, scale: f64) -> Shape {
+        match self {
+            Shape::Sphere(sphere) => Shape::Sphere(sphere.transform(translation, rotation, scale)),
+            Shape::Triangle(triangle) => Shape::Triangle(triangle.transform(translation, rotation, scale)),
+        }
     }
 }
 
-impl Clone for Box<dyn Shape> {
-    fn clone(&self) -> Box<dyn Shape> {
-        self.clone_box()
+impl BoundedVolume for Shape {
+    fn aabb(&self) -> AABB {
+        match self {
+            Shape::Sphere(sphere) => sphere.aabb(),
+            Shape::Triangle(triangle) => triangle.aabb(),
+        }
+    }
+
+    fn intersect(&self, ray: Ray) -> Option<Collision> {
+        match self {
+            Shape::Sphere(sphere) => sphere.intersect(ray),
+            Shape::Triangle(triangle) => triangle.intersect(ray),
+        }
     }
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct Sphere {
+pub struct SphereShape {
     pub center: Vector3,
     pub radius: f64,
 }
 
-impl BoundedVolume for Sphere {
+impl SphereShape {
+    pub fn transform(&self, translation: Vector3, _: Matrix3, scale: f64) -> SphereShape {
+        SphereShape {
+            center: self.center + translation,
+            radius: self.radius * scale,
+        }
+    }
+}
+
+impl BoundedVolume for SphereShape {
     fn intersect(&self, ray: Ray) -> Option<Collision> {
         let c = self.center;
         let r = self.radius;
@@ -113,15 +141,15 @@ impl BoundedVolume for Sphere {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct Triangle {
+pub struct TriangleShape {
     pub vertices: [Vector3; 3],
     pub surface_normal: Vector3,
     pub vertex_normals: [Vector3; 3],
 }
 
-impl Triangle {
-    pub fn transform(&self, translation: Vector3, rotation: Matrix3, scale: f64) -> Triangle {
-        Triangle {
+impl TriangleShape {
+    pub fn transform(&self, translation: Vector3, rotation: Matrix3, scale: f64) -> TriangleShape {
+        TriangleShape {
             vertices: [
                 rotation.clone() * self.vertices[0] * scale + translation,
                 rotation.clone() * self.vertices[1] * scale + translation,
@@ -137,7 +165,7 @@ impl Triangle {
     }
 }
 
-impl BoundedVolume for Triangle {
+impl BoundedVolume for TriangleShape {
     fn intersect(&self, ray: Ray) -> Option<Collision> {
         let a = self.vertices[0];
         let b = self.vertices[1];

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -151,15 +151,15 @@ impl TriangleShape {
     pub fn transform(&self, translation: Vector3, rotation: Matrix3, scale: f64) -> TriangleShape {
         TriangleShape {
             vertices: [
-                rotation.clone() * self.vertices[0] * scale + translation,
-                rotation.clone() * self.vertices[1] * scale + translation,
-                rotation.clone() * self.vertices[2] * scale + translation,
+                rotation * self.vertices[0] * scale + translation,
+                rotation * self.vertices[1] * scale + translation,
+                rotation * self.vertices[2] * scale + translation,
             ],
             surface_normal: rotation.clone() * self.surface_normal,
             vertex_normals: [
-                rotation.clone() * self.vertex_normals[0],
-                rotation.clone() * self.vertex_normals[1],
-                rotation.clone() * self.vertex_normals[2],
+                rotation * self.vertex_normals[0],
+                rotation * self.vertex_normals[1],
+                rotation * self.vertex_normals[2],
             ],
         }
     }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -3,9 +3,9 @@ use std::ops;
 use crate::vector::Vector3;
 
 // 3x3 Matrix
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Matrix3 {
-    components: Vec<f64>,
+    components: [f64; 9],
 }
 
 // Methods
@@ -14,16 +14,17 @@ impl Matrix3 {
     pub fn get(&self, r: usize, c: usize) -> f64 {
         self.components[r * 3 + c]
     }
+
+    #[inline]
+    fn set(&mut self, r: usize, c: usize, v: f64) {
+        self.components[r * 3 + c] = v;
+    }
 }
 
 // Constructors.
 impl Matrix3 {
-    pub fn from_vec(components: Vec<f64>) -> Matrix3 {
-        Matrix3 { components }
-    }
-
     pub fn zero() -> Matrix3 {
-        Matrix3::from_vec(vec![0.0; 9])
+        Matrix3{ components: [0.0; 9] }
     }
 
     pub fn rotation(yaw: f64, pitch: f64, roll: f64) -> Matrix3 {
@@ -36,31 +37,37 @@ impl Matrix3 {
     pub fn rotation_x(angle: f64) -> Matrix3 {
         let sin = angle.sin();
         let cos = angle.cos();
-        Matrix3::from_vec(vec![
-            1.0, 0.0, 0.0,
-            0.0, cos, -sin,
-            0.0, sin, cos,
-        ])
+        Matrix3{ 
+            components: [
+                1.0, 0.0, 0.0,
+                0.0, cos, -sin,
+                0.0, sin, cos,
+            ] 
+        }
     }
 
     pub fn rotation_y(angle: f64) -> Matrix3 {
         let sin = angle.sin();
         let cos = angle.cos();
-        Matrix3::from_vec(vec![
-            cos, 0.0, sin,
-            0.0, 1.0, 0.0,
-            -sin, 0.0, cos,
-        ])
+        Matrix3{ 
+            components: [
+                cos, 0.0, sin,
+                0.0, 1.0, 0.0,
+                -sin, 0.0, cos,
+            ] 
+        }
     }
 
     pub fn rotation_z(angle: f64) -> Matrix3 {
         let sin = angle.sin();
         let cos = angle.cos();
-        Matrix3::from_vec(vec![
-            cos, -sin, 0.0,
-            sin, cos, 0.0,
-            0.0, 0.0, 1.0,
-        ])
+        Matrix3{ 
+            components: [
+                cos, -sin, 0.0,
+                sin, cos, 0.0,
+                0.0, 0.0, 1.0,
+            ] 
+        }
     }
 }
 
@@ -68,17 +75,17 @@ impl ops::Mul<Matrix3> for Matrix3 {
     type Output = Matrix3;
 
     fn mul(self, other: Matrix3) -> Matrix3 {
-        let mut out = Vec::with_capacity(9);
+        let mut out = Matrix3::zero();
         for r in 0 .. 3 {
             for c in 0 .. 3 {
                 let mut v = 0.0;
                 for k in 0 .. 3 {
                     v += self.get(r, k) * other.get(k, c);
                 }
-                out.push(v);
+                out.set(r, c, v);
             }
         }
-        Matrix3::from_vec(out)
+        out
     }
 }
 
@@ -96,30 +103,33 @@ impl ops::Mul<Vector3> for Matrix3 {
 
 #[cfg(test)]
 mod test {
-    use crate::paths::matrix::Matrix3;
+    use crate::matrix::Matrix3;
 
     #[test]
     fn test_matrix_multiply() {
-        let m1 = Matrix3::from_vec(
-            vec![
-            1.0, 2.0, 3.0,
-            4.0, 5.0, 6.0,
-            7.0, 8.0, 9.0,
-            ]);
+        let m1 = Matrix3 {
+            components: [
+                1.0, 2.0, 3.0,
+                4.0, 5.0, 6.0,
+                7.0, 8.0, 9.0,
+            ]
+        };
 
-        let m2 = Matrix3::from_vec(
-            vec![
-            9.0, 8.0, 7.0,
-            6.0, 5.0, 4.0,
-            3.0, 2.0, 1.0,
-            ]);
+        let m2 = Matrix3 {
+            components: [
+                9.0, 8.0, 7.0,
+                6.0, 5.0, 4.0,
+                3.0, 2.0, 1.0,
+            ]
+        };
 
-        let expected = Matrix3::from_vec(
-            vec![
-            30.0, 24.0, 18.0,
-            84.0, 69.0, 54.0,
-            138.0, 114.0, 90.0,
-            ]);
+        let expected = Matrix3 {
+            components: [
+                30.0, 24.0, 18.0,
+                84.0, 69.0, 54.0,
+                138.0, 114.0, 90.0,
+            ]
+        };
 
         assert_eq!(m1 * m2, expected);
     }

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -149,7 +149,7 @@ mod test {
     fn test_face() {
         assert_eq!(
             face(CompleteStr("f 43 1 562")),
-            Ok((CompleteStr(""), (43, 1, 562))));
+            Ok((CompleteStr(""), (42, 0, 561))));
     }
 
     #[test]
@@ -168,9 +168,9 @@ mod test {
         assert_eq!(
             faces(CompleteStr("f 1 2 3\nf 4 5 6\nf 7 8 9\n")),
             Ok((CompleteStr(""), vec![
-               (1, 2, 3),
-               (4, 5, 6),
-               (7, 8, 9),
+               (0, 1, 2),
+               (3, 4, 5),
+               (6, 7, 8),
             ])));
     }
 
@@ -182,8 +182,8 @@ mod test {
         assert_eq!(teapot.vertices[3643], Vector3::new(3.434, 2.4729, 0.0));
 
         assert_eq!(teapot.faces.len(), 6320);
-        assert_eq!(teapot.faces[0], (2909, 2921, 2939));
-        assert_eq!(teapot.faces[6319], (3001, 3004, 3022));
+        assert_eq!(teapot.faces[0], (2908, 2920, 2938));
+        assert_eq!(teapot.faces[6319], (3000, 3003, 3021));
     }
 
     fn parse_obj_file(name: &str) -> Model {

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use nom::{digit, double};
 use nom::types::CompleteStr;
 
-use crate::geom::Triangle;
+use crate::geom::Shape;
 use crate::vector::Vector3;
 
 pub struct Model {
@@ -14,7 +14,7 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn resolve_triangles(&self) -> Vec<Triangle> {
+    pub fn resolve_triangles(&self) -> Vec<Shape> {
         // Firstly, compute the face normals.
         let face_normals: Vec<Vector3> = self.faces.iter()
             .map(|&(a, b, c)| {
@@ -60,7 +60,7 @@ impl Model {
                 let surface_normal = face_normals[ix];
                 let vertex_normals = [vn1, vn2, vn3];
 
-                Triangle { vertices, surface_normal, vertex_normals }
+                Shape::triangle(vertices, surface_normal, vertex_normals)
             })
             .collect()
     }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -8,7 +8,7 @@ use crate::vector::Vector3;
 #[derive(Clone)]
 pub struct Object {
     pub shape: Box<dyn Shape>,
-    pub material: Box<dyn Material>,
+    pub material: Material,
 }
 
 impl BoundedVolume for Object {
@@ -78,7 +78,7 @@ impl Scene {
         Scene { camera, skybox, bvh }
     }
 
-    pub fn find_intersection(&self, ray: Ray) -> Option<(Collision, Box<dyn Material>)> {
-        self.bvh.find_intersection(ray).map(|(col, obj)| (col, obj.material.clone()))
+    pub fn find_intersection(&self, ray: Ray) -> Option<(Collision, Material)> {
+        self.bvh.find_intersection(ray).map(|(col, obj)| (col, obj.material))
     }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -22,58 +22,51 @@ impl BoundedVolume for Object {
 }
 
 
-pub trait Skybox : SkyboxClone + Send + Sync {
-    fn ambient_light(&self, direction: Vector3) -> Colour;
+#[derive(Clone, Copy, Debug)]
+pub enum Skybox {
+    Flat(FlatSky),
+    Gradient(GradientSky),
 }
 
-pub trait SkyboxClone {
-    fn clone_box(&self) -> Box<dyn Skybox>;
-}
+impl Skybox {
+    pub fn flat(colour: Colour) -> Skybox {
+        Skybox::Flat(FlatSky{ colour })
+    }
 
-impl <T> SkyboxClone for T where T: 'static + Skybox + Clone {
-    fn clone_box(&self) -> Box<dyn Skybox> {
-        Box::new(self.clone())
+    pub fn gradient(overhead_colour: Colour, horizon_colour: Colour) -> Skybox {
+        Skybox::Gradient(GradientSky{ overhead_colour, horizon_colour })
+    }
+
+    pub fn ambient_light(&self, direction: Vector3) -> Colour {
+        match self {
+            Skybox::Flat(sky) => sky.colour,
+            Skybox::Gradient(sky) => {
+                let cos_theta = direction.dot(Vector3::new(0.0, 1.0, 0.0));
+                sky.overhead_colour * cos_theta + sky.horizon_colour * (1.0 - cos_theta)
+            },
+        }
     }
 }
 
-impl Clone for Box<dyn Skybox> {
-    fn clone(&self) -> Box<dyn Skybox> {
-        self.clone_box()
-    }
-}
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct FlatSky {
     pub colour: Colour,
 }
 
-impl Skybox for FlatSky {
-    fn ambient_light(&self, _direction: Vector3) -> Colour {
-        self.colour
-    }
-}
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct GradientSky {
     pub overhead_colour: Colour,
     pub horizon_colour: Colour,
 }
 
-impl Skybox for GradientSky {
-    fn ambient_light(&self, direction: Vector3) -> Colour {
-        let cos_theta = direction.dot(Vector3::new(0.0, 1.0, 0.0));
-        return self.overhead_colour * cos_theta + self.horizon_colour * (1.0 - cos_theta);
-    }
-}
-
 pub struct Scene {
     pub camera: Camera,
-    pub skybox: Box<dyn Skybox>,
+    pub skybox: Skybox,
     bvh: BVH<Object>,
 }
 
 impl Scene {
-    pub fn new(camera: Camera, objects: Vec<Object>, skybox: Box<dyn Skybox>) -> Scene {
+    pub fn new(camera: Camera, objects: Vec<Object>, skybox: Skybox) -> Scene {
         let bvh = construct_bvh_aac(objects);
         Scene { camera, skybox, bvh }
     }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -7,7 +7,7 @@ use crate::vector::Vector3;
 
 #[derive(Clone)]
 pub struct Object {
-    pub shape: Box<dyn Shape>,
+    pub shape: Shape,
     pub material: Material,
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -253,13 +253,13 @@ pub struct GradientSkyboxDescription {
 }
 
 impl SkyboxDescription {
-    pub fn to_skybox(&self) -> Box<dyn scene::Skybox> {
+    pub fn to_skybox(&self) -> scene::Skybox {
         match self {
-            SkyboxDescription::Flat(sky) => Box::new(scene::FlatSky{ colour: sky.colour.to_colour() }),
-            SkyboxDescription::Gradient(sky) => Box::new(scene::GradientSky{
-                overhead_colour: sky.overhead_colour.to_colour(),
-                horizon_colour: sky.horizon_colour.to_colour(),
-            }),
+            SkyboxDescription::Flat(sky) => scene::Skybox::flat(sky.colour.to_colour()),
+            SkyboxDescription::Gradient(sky) => scene::Skybox::gradient(
+                sky.overhead_colour.to_colour(),
+                sky.horizon_colour.to_colour(),
+            ),
         }
     }
 }


### PR DESCRIPTION
Remove boxing in a bunch of places to attempt to reduce allocations.

Pre-allocate space in `BinaryHeap` inside BVH calculations.

This reduces the time for 100 samples on `teapot.yml` scene from ~47s to ~38s.

Some profiling indicates that we spend ~75% of our time inside `find_intersection`, so any further optimization efforts should focus there.  ~5% is spent just allocating `BinaryHeap`s still, so if we could pool and reuse these we'd gain that 5% easily.  But I couldn't figure out how to get Rust to let me do that.