### PR TITLE
Stream rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,11 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,6 +34,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +114,11 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,9 +129,22 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "memchr"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memoffset"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "nom"
@@ -111,6 +199,7 @@ dependencies = [
 name = "paths"
 version = "0.1.0"
 dependencies = [
+ "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sdl2 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -262,6 +351,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "sdl2"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,16 +459,26 @@ dependencies = [
 
 [metadata]
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+"checksum crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
+"checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+"checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+"checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)" = "413f3dfc802c5dc91dc570b05125b6cda9855edfaa9825c9849807876376e70e"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
+"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+"checksum memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 "checksum nom 4.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22293d25d3f33a8567cc8a1dc20f40c7eeb761ce83d0fcca059858580790cac3"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
@@ -396,6 +500,7 @@ dependencies = [
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum sdl2 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a74c2a98a354b20713b90cce70aef9e927e46110d1bc4ef728fd74e0d53eba60"
 "checksum sdl2-sys 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c543ce8a6e33a30cb909612eeeb22e693848211a84558d5a00bb11e791b7ab7"
 "checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Ryan Norris <rynorris@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+crossbeam = "^0.7.3"
 nom = "^4.2"
 rand = "0.6.5"
 sdl2 = { version = "0.31", features = ["unsafe_textures"] }

--- a/src/bvh.rs
+++ b/src/bvh.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::time::Instant;
 
 use crate::geom::{AABB, BoundedVolume, Collision, Ray};

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,7 +1,6 @@
 use crate::colour::Colour;
 use crate::geom::Ray;
 use crate::matrix::Matrix3;
-use crate::sampling::Sampler;
 use crate::vector::Vector3;
 
 pub struct Image {
@@ -21,15 +20,10 @@ pub struct Camera {
     pub sensor_height: f64,
     pub width: u32,
     pub height: u32,
-    sampler: Box<dyn Sampler>,
-
-    // Current bundle details.
-    bundle_offsets: (f64, f64),
-    bundle_lens_point: Vector3,
 }
 
 impl Camera {
-    pub fn new(width: u32, height: u32, sampler: Box<dyn Sampler>) -> Camera {
+    pub fn new(width: u32, height: u32) -> Camera {
         let camera = Camera {
             location: Vector3::new(0.0, 0.0, 0.0),
             focal_length: 9.86,
@@ -40,25 +34,23 @@ impl Camera {
             sensor_height: height as f64,
             width,
             height,
-            sampler,
-
-            bundle_offsets: (0.0, 0.0),
-            bundle_lens_point: Vector3::new(0.0, 0.0, 0.0),
         };
         camera
     }
 
-    pub fn init_bundle(&mut self) {
-        self.sampler.next();
-        let (jx, jy) = self.sampler.sample_square();
-        self.bundle_offsets = (jx, jy);
-
+    fn point_on_lens(&self, point_on_disk: (f64, f64)) -> Vector3 {
         let aperture_radius = self.focal_length / self.aperture;
-        let (lens_x, lens_y) = self.sampler.sample_disk();
-        self.bundle_lens_point = Vector3::new(lens_x * aperture_radius, lens_y * aperture_radius, 0.0);
+        let (lens_x, lens_y) = point_on_disk;
+        Vector3::new(lens_x * aperture_radius, lens_y * aperture_radius, 0.0)
     }
 
-    pub fn get_ray_for_pixel(&mut self, x: u32, y: u32) -> (Ray, f64) {
+    pub fn get_ray_for_pixel(
+        &mut self,
+        x: u32,
+        y: u32,
+        point_on_square: (f64, f64),
+        point_on_disk: (f64, f64)
+    ) -> (Ray, f64) {
         // We'll compute the outbound ray first in lens-space where the centre of 
         // the lens is at the origin.
         // Then transform into world space.
@@ -70,7 +62,7 @@ impl Camera {
         let p = (f * v) / (v - f);
 
         // k = point on sensor
-        let (x_offset, y_offset) = self.bundle_offsets;
+        let (x_offset, y_offset) = point_on_square;
         let x_scale = self.sensor_width / (self.width as f64);
         let y_scale = self.sensor_height / (self.height as f64);
         let image_x = (x as f64) - (self.width as f64) / 2.0 + x_offset;
@@ -80,7 +72,7 @@ impl Camera {
         let k = Vector3::new(image_x * x_scale, image_y * y_scale, -self.distance_from_lens);
 
         // l = point on lens
-        let l = self.bundle_lens_point;
+        let l = self.point_on_lens(point_on_disk);
 
         // this equation for ray direction precomputed by hand to collapse all the terms that go away.
         let dir = ((k * (p/v)) + l) * -1;

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -45,7 +45,7 @@ impl Camera {
     }
 
     pub fn get_ray_for_pixel(
-        &mut self,
+        &self,
         x: u32,
         y: u32,
         point_on_square: (f64, f64),

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ fn main() {
     println!("Contructing scene...");
     let width = scene_description.camera.image_width;
     let height = scene_description.camera.image_height;
+    let num_pixels = (width * height) as u64;
 
     // Initialize SDL and create window.
     let sdl_context = sdl2::init().unwrap();
@@ -85,8 +86,6 @@ fn main() {
 
     let mut is_running = true;
 
-    let mut num_samples = 0;
-
     let start_time = Instant::now();
 
     while is_running {
@@ -94,8 +93,9 @@ fn main() {
         renderer.fill_request_queue();
         let image = renderer.render();
 
-        num_samples += 1;
-        println!("[{:.1?}] Num samples: {:?}", start_time.elapsed(), num_samples);
+        let num_rays = renderer.num_rays_cast();
+        let rays_per_pixel = num_rays / num_pixels;
+        println!("[{:.1?}] Num rays: {} ({} per pixel)", start_time.elapsed(), num_rays, rays_per_pixel);
 
         for ix in 0 .. image.pixels.len() {
             let colour = image.pixels[ix];
@@ -138,7 +138,6 @@ fn main() {
                          renderer.scene.camera.distance_from_lens,
                          renderer.scene.camera.aperture);
                 renderer.reset();
-                num_samples = 0;
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,9 @@ pub mod sampling;
 pub mod scene;
 pub mod serde;
 pub mod stress;
+pub mod trace;
 pub mod vector;
+pub mod worker;
 
 use std::env;
 use std::fs::File;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,8 @@ fn main() {
         stress::generate_stress_scene(500)
     });
 
-    let scene = scene_description.to_scene();
+    let camera = scene_description.camera();
+    let scene = scene_description.scene();
 
     println!("Contructing scene...");
     let width = scene_description.camera.image_width;
@@ -81,7 +82,7 @@ fn main() {
     let mut pitch: f64 = scene_description.camera.orientation.pitch;
     let mut roll: f64 = scene_description.camera.orientation.roll;
 
-    let mut renderer = Renderer::new(Arc::new(scene), 4);
+    let mut renderer = Renderer::new(camera, Arc::new(scene), 4);
 
     let mut texture_buffer: Vec<u8> = vec![0; (width * height * 3) as usize];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,8 @@ fn main() {
     let start_time = Instant::now();
 
     while is_running {
-        renderer.trace_full_pass();
+        renderer.drain_result_queue();
+        renderer.fill_request_queue();
         let image = renderer.render();
 
         num_samples += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ pub mod worker;
 use std::env;
 use std::fs::File;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use crate::renderer::Renderer;
 use crate::serde::SceneDescription;
@@ -130,22 +130,13 @@ fn main() {
                    Some(Keycode::K) => pitch += 0.1,
                    Some(Keycode::J) => yaw += 0.1,
                    Some(Keycode::L) => yaw -= 0.1,
-                   Some(Keycode::W) => Arc::get_mut(&mut renderer.scene).expect("Can get mutable reference to scene").camera.distance_from_lens += 0.00001,
-                   Some(Keycode::Q) => Arc::get_mut(&mut renderer.scene).expect("Can get mutable reference to scene").camera.distance_from_lens -= 0.00001,
                    _ => should_reset = false,
                 },
                 _ => should_reset = false,
             }
 
             if should_reset {
-                println!("Resetting render");
-                Arc::get_mut(&mut renderer.scene).expect("Can get mutable reference to scene").camera.set_orientation(yaw, pitch, roll);
-                println!("Yaw: {:.1}, Pitch: {:.1}, Roll: {:.1}", yaw, pitch, roll);
-                println!("F: {:.1}, V: {:.1}, A: {:.1}",
-                         renderer.scene.camera.focal_length,
-                         renderer.scene.camera.distance_from_lens,
-                         renderer.scene.camera.aperture);
-                renderer.reset();
+                renderer.reorient_camera(yaw, pitch, roll);
             }
         }
 
@@ -153,4 +144,7 @@ fn main() {
         governer.end_frame();
         frame_count += 1;
     }
+
+    // Shutdown.
+    renderer.shutdown();
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -48,7 +48,6 @@ impl Renderer {
     }
 
     pub fn fill_request_queue(&mut self) {
-        println!("Queue still had {} requests in.", self.request_tx.len());
         while !self.request_tx.is_full() {
             let request = self.next_request();
             match self.request_tx.send(request) {
@@ -61,8 +60,8 @@ impl Renderer {
     pub fn drain_result_queue(&mut self) {
         let results = self.result_rx.try_iter().collect::<Vec<worker::RenderResult>>();
         results.iter().for_each(|result| {
+            self.num_rays_cast += result.samples.len() as u64;
             result.samples.iter().for_each(|(x, y, colour)| {
-                self.num_rays_cast += 1;
                 self.estimator.update_pixel(*x as usize, *y as usize, *colour);
             });
         });

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -27,7 +27,7 @@ impl Renderer {
         let estimator = Estimator::new(scene.camera.width as usize, scene.camera.height as usize);
         let pool = ThreadPool::new(num_workers);
 
-        let (request_tx, request_rx) = channel::bounded::<worker::RenderRequest>(100);
+        let (request_tx, request_rx) = channel::bounded::<worker::RenderRequest>(200);
         let (result_tx, result_rx) = channel::unbounded::<worker::RenderResult>();
 
         // Spin up 4 workers.
@@ -48,6 +48,10 @@ impl Renderer {
     }
 
     pub fn fill_request_queue(&mut self) {
+        if self.request_tx.is_empty() {
+            println!("[WARN] Request queue was empty");
+        }
+
         while !self.request_tx.is_full() {
             let request = self.next_request();
             match self.request_tx.send(request) {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,27 +1,25 @@
 use std::sync::{Arc};
-use std::sync::mpsc::channel;
 
-use rand;
-use rand::Rng;
+use crossbeam::channel;
 use threadpool::ThreadPool;
 
 use crate::camera::Image;
-use crate::colour::Colour;
-use crate::geom::Ray;
 use crate::pixels::Estimator;
 use crate::scene::Scene;
+use crate::worker;
 
 pub struct Renderer {
     pub scene: Arc<Scene>,
     estimator: Estimator,
     pool: ThreadPool,
+    num_workers: usize,
 }
 
 impl Renderer {
     pub fn new(scene: Arc<Scene>, num_workers: usize) -> Renderer {
         let estimator = Estimator::new(scene.camera.width as usize, scene.camera.height as usize);
         let pool = ThreadPool::new(num_workers);
-        Renderer{ scene, estimator, pool}
+        Renderer{ scene, estimator, pool, num_workers }
     }
 
     pub fn render(&self) -> Image {
@@ -29,85 +27,46 @@ impl Renderer {
     }
 
     pub fn trace_full_pass(&mut self) {
-        let (tx, rx) = channel::<(u32, u32, Colour)>();
+        let (request_tx, request_rx) = channel::unbounded::<worker::RenderRequest>();
+        let (result_tx, result_rx) = channel::unbounded::<worker::RenderResult>();
 
+        // HACK
         Arc::get_mut(&mut self.scene).expect("Can get mutable reference to scene").camera.init_bundle();
 
-        for x in 0 .. self.scene.camera.width {
-            let tx = tx.clone();
-            let scene = self.scene.clone();
-            let mut camera = self.scene.camera.clone();
-
-            self.pool.execute(move|| {
-                for y in 0 .. camera.height {
-                    let (ray, weight) = camera.get_ray_for_pixel(x, y);
-                    let colour = Renderer::trace_ray(&scene, ray) * weight;
-                    tx.send((x, y, colour)).expect("can send result back");
-                }
-            });
+        // Spin up 4 workers.
+        for _ in 0..self.num_workers {
+            let worker = worker::Worker::new(request_rx.clone(), result_tx.clone(), self.scene.clone());
+            self.pool.execute(move|| worker.run_forever());
         }
 
-        self.pool.join();
+        // Send requests off for slices of the image.
+        for x in 0 .. self.scene.camera.width {
+            let request = worker::RenderRequest{
+                top_left: (x, 0),
+                bottom_right: (x, self.scene.camera.height - 1),
+                num_samples: 1,
+            };
+
+            match request_tx.send(request) {
+                Ok(_) => (),
+                Err(err) => panic!(err),
+            }
+        }
+
+        // Receive results.
+        result_rx.iter().take((self.scene.camera.width * 1) as usize).for_each(|result| {
+            result.samples.iter().for_each(|(x, y, colour)| {
+                self.estimator.update_pixel(*x as usize, *y as usize, *colour);
+            });
+        });
 
         if self.pool.panic_count() > 0 {
             panic!("{} rendering threads panicked while rendering.", self.pool.panic_count());
         }
-
-        let num_pixels = self.scene.camera.height * self.scene.camera.width;
-        rx.iter().take(num_pixels as usize).for_each(|(x, y, colour)| {
-            self.estimator.update_pixel(x as usize, y as usize, colour);
-        });
     }
 
     pub fn reset(&mut self) {
         self.estimator = Estimator::new(self.scene.camera.width as usize, self.scene.camera.height as usize);
     }
 
-    fn trace_ray(scene: &Scene, mut ray: Ray) -> Colour {
-        let mut throughput = Colour::WHITE;
-        let mut colour = Colour::BLACK;
-        let mut loops = 0;
-
-        loop {
-            if loops > 10 {
-                break;
-            }
-
-            let (collision, material) = if let Some((c, m)) = scene.find_intersection(ray) {
-                (c, m)
-            } else {
-                colour += throughput * scene.skybox.ambient_light(ray.direction * -1);
-                break;
-            };
-
-            let cos_out: f64 = ray.direction.dot(collision.normal);
-
-            let emittance = material.emittance(ray.direction * -1, cos_out);
-
-            let new_ray = Ray::new(
-                collision.location + collision.normal * 0.0001,  // Add the normal as a hack so it doesn't collide with the same object again.
-                material.sample_pdf(ray.direction * -1, collision.normal),
-            );
-
-            let pdf = material.weight_pdf(ray.direction * -1, new_ray.direction * -1, collision.normal);
-
-            let attenuation = material.brdf(ray.direction * -1, new_ray.direction * -1, collision.normal) / pdf;
-            throughput = throughput * attenuation;
-
-            colour += emittance * throughput;
-
-            // Chance for the material to eat the ray.
-            let survival_chance = throughput.max();
-            if rand::thread_rng().gen::<f64>() > survival_chance {
-                break;
-            }
-
-            throughput = throughput / survival_chance;
-
-            ray = new_ray;
-            loops += 1;
-        }
-
-        colour
-    }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -27,7 +27,7 @@ impl Renderer {
         let estimator = Estimator::new(scene.camera.width as usize, scene.camera.height as usize);
         let pool = ThreadPool::new(num_workers);
 
-        let (request_tx, request_rx) = channel::bounded::<worker::RenderRequest>(1000);
+        let (request_tx, request_rx) = channel::bounded::<worker::RenderRequest>(100);
         let (result_tx, result_rx) = channel::unbounded::<worker::RenderResult>();
 
         // Spin up 4 workers.

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -12,51 +12,47 @@ pub struct Renderer {
     pub scene: Arc<Scene>,
     estimator: Estimator,
     pool: ThreadPool,
-    num_workers: usize,
+    request_tx: channel::Sender<worker::RenderRequest>,
+    result_rx: channel::Receiver<worker::RenderResult>,
+    
+    // Request iteration state.
+    cur_x: u32,
 }
 
 impl Renderer {
     pub fn new(scene: Arc<Scene>, num_workers: usize) -> Renderer {
         let estimator = Estimator::new(scene.camera.width as usize, scene.camera.height as usize);
         let pool = ThreadPool::new(num_workers);
-        Renderer{ scene, estimator, pool, num_workers }
+
+        let (request_tx, request_rx) = channel::bounded::<worker::RenderRequest>(1000);
+        let (result_tx, result_rx) = channel::unbounded::<worker::RenderResult>();
+
+        // Spin up 4 workers.
+        for _ in 0..num_workers {
+            let worker = worker::Worker::new(request_rx.clone(), result_tx.clone(), scene.clone());
+            pool.execute(move|| worker.run_forever());
+        }
+
+        Renderer{ scene, estimator, pool, request_tx, result_rx, cur_x: 0 }
     }
 
     pub fn render(&self) -> Image {
         self.estimator.render()
     }
 
-    pub fn trace_full_pass(&mut self) {
-        let (request_tx, request_rx) = channel::unbounded::<worker::RenderRequest>();
-        let (result_tx, result_rx) = channel::unbounded::<worker::RenderResult>();
-
-        // Spin up 4 workers.
-        for _ in 0..self.num_workers {
-            let worker = worker::Worker::new(request_rx.clone(), result_tx.clone(), self.scene.clone());
-            self.pool.execute(move|| worker.run_forever());
-        }
-
-        // Send requests off for slices of the image.
-        let pattern_size: (u32, u32) = (4, 4);
-        for x in 0 .. self.scene.camera.width {
-            let request = worker::RenderRequest{
-                top_left: (x, 0),
-                bottom_right: (x, self.scene.camera.height - 1),
-                pattern_size,
-            };
-
-            match request_tx.send(request) {
+    pub fn fill_request_queue(&mut self) {
+        while !self.request_tx.is_full() {
+            let request = self.next_request();
+            match self.request_tx.send(request) {
                 Ok(_) => (),
                 Err(err) => panic!(err),
             }
         }
+    }
 
-        let num_results = self.scene.camera.width * pattern_size.0 * pattern_size.1;
-
-        // Receive results.
-        let mut n = 0;
-        result_rx.iter().take((num_results) as usize).for_each(|result| {
-            n += 1;
+    pub fn drain_result_queue(&mut self) {
+        let results = self.result_rx.try_iter().collect::<Vec<worker::RenderResult>>();
+        results.iter().for_each(|result| {
             result.samples.iter().for_each(|(x, y, colour)| {
                 self.estimator.update_pixel(*x as usize, *y as usize, *colour);
             });
@@ -71,4 +67,19 @@ impl Renderer {
         self.estimator = Estimator::new(self.scene.camera.width as usize, self.scene.camera.height as usize);
     }
 
+    fn next_request(&mut self) -> worker::RenderRequest {
+        let pattern_size: (u32, u32) = (4, 4);
+        let x = self.cur_x;
+
+        self.cur_x += 1;
+        if self.cur_x >= self.scene.camera.width {
+            self.cur_x = 0;
+        }
+
+        worker::RenderRequest{
+            top_left: (x, 0),
+            bottom_right: (x, self.scene.camera.height - 1),
+            pattern_size,
+        }
+    }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -37,7 +37,7 @@ impl Renderer {
         }
 
         // Send requests off for slices of the image.
-        let pattern_size: (u32, u32) = (5, 5);
+        let pattern_size: (u32, u32) = (4, 4);
         for x in 0 .. self.scene.camera.width {
             let request = worker::RenderRequest{
                 top_left: (x, 0),

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -30,9 +30,6 @@ impl Renderer {
         let (request_tx, request_rx) = channel::unbounded::<worker::RenderRequest>();
         let (result_tx, result_rx) = channel::unbounded::<worker::RenderResult>();
 
-        // HACK
-        Arc::get_mut(&mut self.scene).expect("Can get mutable reference to scene").camera.init_bundle();
-
         // Spin up 4 workers.
         for _ in 0..self.num_workers {
             let worker = worker::Worker::new(request_rx.clone(), result_tx.clone(), self.scene.clone());
@@ -40,11 +37,12 @@ impl Renderer {
         }
 
         // Send requests off for slices of the image.
+        let pattern_size: (u32, u32) = (5, 5);
         for x in 0 .. self.scene.camera.width {
             let request = worker::RenderRequest{
                 top_left: (x, 0),
                 bottom_right: (x, self.scene.camera.height - 1),
-                num_samples: 1,
+                pattern_size,
             };
 
             match request_tx.send(request) {
@@ -53,8 +51,12 @@ impl Renderer {
             }
         }
 
+        let num_results = self.scene.camera.width * pattern_size.0 * pattern_size.1;
+
         // Receive results.
-        result_rx.iter().take((self.scene.camera.width * 1) as usize).for_each(|result| {
+        let mut n = 0;
+        result_rx.iter().take((num_results) as usize).for_each(|result| {
+            n += 1;
             result.samples.iter().for_each(|(x, y, colour)| {
                 self.estimator.update_pixel(*x as usize, *y as usize, *colour);
             });

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -69,10 +69,10 @@ impl Sampler for UniformSampler {
 // See https://graphics.pixar.com/library/MultiJitteredSampling/paper.pdf for details.
 #[derive(Clone, Debug)]
 pub struct CorrelatedMultiJitteredSampler {
-    p: u32,
-    m: u32,
-    n: u32,
-    s: u32,
+    p: u32,  // Pattern seed
+    m: u32,  // Width
+    n: u32,  // Height
+    s: u32,  // Sample index
 }
 
 impl CorrelatedMultiJitteredSampler {

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -259,7 +259,6 @@ impl DiskSampler for CorrelatedMultiJitteredSampler {
 
             let theta = 2.0 * PI * x;
             let r = y.sqrt();
-            println!("x = {}, y = {}, r = {}, t = {}", x, y, r, theta);
             Some((r * theta.cos(), r * theta.sin()))
         }
     }

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -259,6 +259,7 @@ impl DiskSampler for CorrelatedMultiJitteredSampler {
 
             let theta = 2.0 * PI * x;
             let r = y.sqrt();
+            println!("x = {}, y = {}, r = {}, t = {}", x, y, r, theta);
             Some((r * theta.cos(), r * theta.sin()))
         }
     }
@@ -324,18 +325,20 @@ mod test {
 
         // Hard-code expected values to ensure that the seed is stable across test runs.
         let expected = vec![
-            (0.5116932952906768, 0.11128139036233547),
-            (-0.19882727188585797, -0.3074945110868627),
-            (0.047818668766274705, 0.7212367390953817),
-            (-0.042991584398592714, -0.6502885045286344),
-            (-0.9609023952351098, 0.17826224531019477),
-            (0.7638722573236012, -0.47610578960668487),
-            (1.0639995674541876, 0.35499168995912256),
+            (0.23288271976954444, 0.3020407408384594),
+            (-0.41231103969933375, -0.00884025347340132),
+            (-0.01713192576599384, 0.6485187612468607),
+            (0.38017576583611823, -0.7185092520948844),
+            (-0.7994905690029475, 0.35683991876591936),
+            (0.9139355167587502, -0.3308265058968712)
         ];
 
         let actual = pattern.collect::<Vec<(f64, f64)>>();
         assert_eq!(actual, expected);
-        for (x, y) in actual {
+
+        // Now test all values are within bounds using a very large pattern.
+        let large_pattern = CorrelatedMultiJitteredSampler::new(0, 100, 100).pattern::<Disk>();
+        for (x, y) in large_pattern {
             assert_eq!(is_in_unit_disk(x, y), true);
         }
     }
@@ -346,18 +349,20 @@ mod test {
 
         // Hard-code expected values to ensure that the seed is stable across test runs.
         let expected = vec![
-            (0.5116932952906768, 0.11128139036233547),
-            (-0.19882727188585797, -0.3074945110868627),
-            (0.047818668766274705, 0.7212367390953817),
-            (-0.042991584398592714, -0.6502885045286344),
-            (-0.9609023952351098, 0.17826224531019477),
-            (0.7638722573236012, -0.47610578960668487),
-            (1.0639995674541876, 0.35499168995912256),
+            (0.14546297029350555, 0.14546297029350555),
+            (0.5034118768727529, 0.17007854353941954),
+            (0.25420341990294765, 0.4208700865696143),
+            (0.8274558249416957, 0.660789158275029),
+            (0.43318656421619134, 0.7665198975495247),
+            (0.9447243057970165, 0.9447243057970164)
         ];
 
         let actual = pattern.collect::<Vec<(f64, f64)>>();
         assert_eq!(actual, expected);
-        for (x, y) in actual {
+        
+        // Now test all values are within bounds using a very large pattern.
+        let large_pattern = CorrelatedMultiJitteredSampler::new(0, 100, 100).pattern::<Square>();
+        for (x, y) in large_pattern {
             assert_eq!(is_in_unit_square(x, y), true);
         }
     }

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -2,65 +2,164 @@ use std::f64::consts::PI;
 
 use rand;
 use rand::Rng;
+use rand::rngs::StdRng;
+use rand::distributions::Uniform;
+use rand::SeedableRng;
 
-
-pub trait Sampler : SamplerClone + Send + Sync {
-    // Moves on to the next sample.
-    fn next(&mut self);
-
-    // Samples the unit square, returning x, y.
-    fn sample_square(&mut self) -> (f64, f64);
-
-    // Samples the unit disk, returning x, y.
-    fn sample_disk(&mut self) -> (f64, f64);
+pub trait IntoPattern<S> {
+    fn pattern<D>(self) -> Pattern<D, S>
+    where Pattern<D, S> : CreatePattern<D, S>;
 }
 
-pub trait SamplerClone {
-    fn clone_box(&self) -> Box<dyn Sampler>;
-}
-
-impl <T> SamplerClone for T where T: 'static + Sampler + Clone {
-    fn clone_box(&self) -> Box<dyn Sampler> {
-        Box::new(self.clone())
+impl <S> IntoPattern<S> for S {
+    fn pattern<D>(self) -> Pattern<D, S>
+    where Pattern<D, S> : CreatePattern<D, S> {
+        Pattern::new(self)
     }
 }
 
-impl Clone for Box<dyn Sampler> {
-    fn clone(&self) -> Box<dyn Sampler> {
-        self.clone_box()
+#[derive(Clone, Debug)]
+pub struct Pattern<Domain, T> {
+    domain: Domain,
+    sampler: T,
+}
+
+pub trait CreatePattern<D, S> {
+    fn new(sampler: S) -> Pattern<D, S>;
+}
+
+impl <S> CreatePattern<Square, S> for Pattern<Square, S> {
+    fn new(sampler: S) -> Pattern<Square, S> { 
+        Pattern{ domain: Square, sampler }
+    }
+}
+
+impl <S> CreatePattern<Disk, S> for Pattern<Disk, S> {
+    fn new(sampler: S) -> Pattern<Disk, S> { 
+        Pattern{ domain: Disk, sampler }
+    }
+}
+
+impl <T> Iterator for Pattern<Square, T>
+where Square : SampleFrom<T> {
+    type Item = (f64, f64);
+
+    fn next(&mut self) -> Option<(f64, f64)> {
+        Square::sample_from(&mut self.sampler)
+    }
+}
+
+impl <T> Iterator for Pattern<Disk, T>
+where Disk : SampleFrom<T> {
+    type Item = (f64, f64);
+
+    fn next(&mut self) -> Option<(f64, f64)> {
+        Disk::sample_from(&mut self.sampler)
+    }
+}
+
+pub struct Square;
+pub struct Disk;
+
+pub trait SampleFrom<T> {
+    fn sample_from(sampler: &mut T) -> Option<(f64, f64)>;
+}
+
+impl <T> SampleFrom<T> for Square
+where T : SquareSampler {
+    fn sample_from(sampler: &mut T) -> Option<(f64, f64)> {
+        sampler.next_sample_square()
+    }
+}
+
+impl <T> SampleFrom<T> for Disk
+where T : DiskSampler {
+    fn sample_from(sampler: &mut T) -> Option<(f64, f64)> {
+        sampler.next_sample_disk()
+    }
+}
+
+pub trait SquareSampler {
+    fn next_sample_square(&mut self) -> Option<(f64, f64)>;
+}
+
+pub trait DiskSampler {
+    fn next_sample_disk(&mut self) -> Option<(f64, f64)>;
+}
+
+#[derive(Clone, Debug)]
+pub enum Sampler {
+    Uniform(UniformSampler),
+    CMJ(CorrelatedMultiJitteredSampler),
+}
+
+impl SquareSampler for Sampler {
+    fn next_sample_square(&mut self) -> Option<(f64, f64)> {
+        match self {
+            Sampler::Uniform(s) => s.next_sample_square(),
+            Sampler::CMJ(s) => s.next_sample_square(),
+        }
+    }
+}
+
+impl DiskSampler for Sampler {
+    fn next_sample_disk(&mut self) -> Option<(f64, f64)> {
+        match self {
+            Sampler::Uniform(s) => s.next_sample_disk(),
+            Sampler::CMJ(s) => s.next_sample_disk(),
+        }
     }
 }
 
 #[derive(Clone, Debug)]
 pub struct UniformSampler {
-    r1: f64,
-    r2: f64,
+    rng: rand::rngs::StdRng,
+    distribution: Uniform<f64>,
+    remaining_samples: u32,
 }
 
 impl UniformSampler {
-    pub fn new() -> UniformSampler {
-        let mut rng = rand::thread_rng();
-        UniformSampler{ r1: rng.gen(), r2: rng.gen() }
+    pub fn new(p: u32, m: u32, n: u32) -> UniformSampler {
+        let rng: StdRng = SeedableRng::seed_from_u64(p as u64);
+        let distribution = Uniform::new(0.0, 1.0);
+        UniformSampler{
+            rng,
+            distribution,
+            remaining_samples: m * n,
+        }
+    }
+
+    pub fn random(m: u32, n: u32) -> UniformSampler {
+        let p: u32 = rand::thread_rng().gen();
+        UniformSampler::new(p, m, n)
+    }
+
+    fn random_number(&mut self) -> f64 {
+        self.rng.sample(self.distribution)
     }
 }
 
-impl Sampler for UniformSampler {
-    fn next(&mut self) {
-        let mut rng = rand::thread_rng();
-        self.r1 = rng.gen();
-        self.r2 = rng.gen();
+impl SquareSampler for UniformSampler {
+    fn next_sample_square(&mut self) -> Option<(f64, f64)> {
+        return if self.remaining_samples == 0 {
+            None
+        } else {
+            self.remaining_samples -= 1;
+            Some((self.random_number(), self.random_number()))
+        }
     }
+}
 
-    fn sample_square(&mut self) -> (f64, f64) {
-        let mut rng = rand::thread_rng();
-        (rng.gen(), rng.gen())
-    }
-
-    fn sample_disk(&mut self) -> (f64, f64) {
-        let mut rng = rand::thread_rng();
-        let r = rng.gen::<f64>();
-        let theta = rng.gen::<f64>();
-        (r * theta.cos(), r * theta.sin())
+impl DiskSampler for UniformSampler {
+    fn next_sample_disk(&mut self) -> Option<(f64, f64)> {
+        return if self.remaining_samples == 0 {
+            None
+        } else {
+            self.remaining_samples -= 1;
+            let r = self.random_number();
+            let theta = self.random_number();
+            Some((r * theta.cos(), r * theta.sin()))
+        }
     }
 }
 
@@ -77,6 +176,11 @@ pub struct CorrelatedMultiJitteredSampler {
 
 impl CorrelatedMultiJitteredSampler {
     pub fn new(p: u32, m: u32, n: u32) -> CorrelatedMultiJitteredSampler {
+        CorrelatedMultiJitteredSampler{ p, m, n, s: 0 }
+    }
+
+    pub fn random(m: u32, n: u32) -> CorrelatedMultiJitteredSampler {
+        let p: u32 = rand::thread_rng().gen();
         CorrelatedMultiJitteredSampler{ p, m, n, s: 0 }
     }
 
@@ -131,26 +235,130 @@ impl CorrelatedMultiJitteredSampler {
     }
 }
 
-impl Sampler for CorrelatedMultiJitteredSampler {
-    fn next(&mut self) {
-        self.s += 1;
-        if self.s > self.m * self.n {
-            self.p += 1;
-            self.s = 0;
+impl SquareSampler for CorrelatedMultiJitteredSampler {
+    fn next_sample_square(&mut self) -> Option<(f64, f64)> {
+        if self.s >= self.m * self.n {
+            None
+        } else {
+            let sample = CorrelatedMultiJitteredSampler::cmj(self.s, self.m, self.n, self.p);
+            self.s += 1;
+            Some(sample)
+        }
+    }
+}
+
+impl DiskSampler for CorrelatedMultiJitteredSampler {
+    fn next_sample_disk(&mut self) -> Option<(f64, f64)> {
+        if self.s >= self.m * self.n {
+            None
+        } else {
+            // Sample the square and then map to the disk.
+            // Only works if m ~= n
+            let (x, y) = CorrelatedMultiJitteredSampler::cmj(self.s, self.m, self.n, self.p);
+            self.s += 1;
+
+            let theta = 2.0 * PI * x;
+            let r = y.sqrt();
+            Some((r * theta.cos(), r * theta.sin()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::sampling::*;
+
+    fn is_in_unit_disk(x: f64, y: f64) -> bool {
+        x * x + y * y <= 1.0
+    }
+
+    fn is_in_unit_square(x: f64, y: f64) -> bool {
+        x >= 0.0 && x <= 1.0 && y >= 0.0 && y <= 1.0
+    }
+
+    #[test]
+    fn test_uniform_disk() {
+        let pattern = UniformSampler::new(0, 2, 3).pattern::<Disk>();
+
+        // Hard-code expected values to ensure that the seed is stable across test runs.
+        let expected = vec![
+            (0.27099483228008736, 0.3541936719985136),
+            (0.3199761067608373, 0.0034989080440785106),
+            (0.00018841126354844867, 0.00005758516026271694),
+            (0.4444775002102809, 0.35185244122547316),
+            (0.4535960961658139, 0.19369113347312825),
+            (0.34648254086248437, 0.32805505516760064),
+        ];
+
+        let actual = pattern.collect::<Vec<(f64, f64)>>();
+        assert_eq!(actual, expected);
+        for (x, y) in actual {
+            assert_eq!(is_in_unit_disk(x, y), true);
         }
     }
 
-    fn sample_square(&mut self) -> (f64, f64) {
-        CorrelatedMultiJitteredSampler::cmj(self.s, self.m, self.n, self.p)
+    #[test]
+    fn test_uniform_square() {
+        let pattern = UniformSampler::new(0, 2, 3).pattern::<Square>();
+
+        // Hard-code expected values to ensure that the seed is stable across test runs.
+        let expected = vec![
+            (0.44597237179706917, 0.9176988201469243),
+            (0.3199952363009857, 0.010934468302049138),
+            (0.00019701485962841936, 0.29661887443159096),
+            (0.5668865747127068, 0.6696035669674656),
+            (0.49321970119103264, 0.4035738877175896),
+            (0.47714805914259006, 0.7580862631517262),
+        ];
+
+        let actual = pattern.collect::<Vec<(f64, f64)>>();
+        assert_eq!(actual, expected);
+        for (x, y) in actual {
+            assert_eq!(is_in_unit_square(x, y), true);
+        }
     }
 
-    fn sample_disk(&mut self) -> (f64, f64) {
-        // Sample the square and then map to the disk.
-        // Only works if m ~= n
-        let (x, y) = CorrelatedMultiJitteredSampler::cmj(self.s, self.m, self.n, self.p + 1);
+    #[test]
+    fn test_cmj_disk() {
+        let pattern = CorrelatedMultiJitteredSampler::new(0, 2, 3).pattern::<Disk>();
 
-        let theta = 2.0 * PI * x;
-        let r = y.sqrt();
-        (r * theta.cos(), r * theta.sin())
+        // Hard-code expected values to ensure that the seed is stable across test runs.
+        let expected = vec![
+            (0.5116932952906768, 0.11128139036233547),
+            (-0.19882727188585797, -0.3074945110868627),
+            (0.047818668766274705, 0.7212367390953817),
+            (-0.042991584398592714, -0.6502885045286344),
+            (-0.9609023952351098, 0.17826224531019477),
+            (0.7638722573236012, -0.47610578960668487),
+            (1.0639995674541876, 0.35499168995912256),
+        ];
+
+        let actual = pattern.collect::<Vec<(f64, f64)>>();
+        assert_eq!(actual, expected);
+        for (x, y) in actual {
+            assert_eq!(is_in_unit_disk(x, y), true);
+        }
+    }
+
+    #[test]
+    fn test_cmj_square() {
+        let pattern = CorrelatedMultiJitteredSampler::new(0, 2, 3).pattern::<Square>();
+
+        // Hard-code expected values to ensure that the seed is stable across test runs.
+        let expected = vec![
+            (0.5116932952906768, 0.11128139036233547),
+            (-0.19882727188585797, -0.3074945110868627),
+            (0.047818668766274705, 0.7212367390953817),
+            (-0.042991584398592714, -0.6502885045286344),
+            (-0.9609023952351098, 0.17826224531019477),
+            (0.7638722573236012, -0.47610578960668487),
+            (1.0639995674541876, 0.35499168995912256),
+        ];
+
+        let actual = pattern.collect::<Vec<(f64, f64)>>();
+        assert_eq!(actual, expected);
+        for (x, y) in actual {
+            assert_eq!(is_in_unit_square(x, y), true);
+        }
     }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,5 +1,4 @@
 use crate::bvh::{construct_bvh_aac, BVH};
-use crate::camera::Camera;
 use crate::colour::Colour;
 use crate::geom::{AABB, BoundedVolume, Collision, Shape, Ray};
 use crate::material::Material;
@@ -60,15 +59,14 @@ pub struct GradientSky {
 }
 
 pub struct Scene {
-    pub camera: Camera,
     pub skybox: Skybox,
     bvh: BVH<Object>,
 }
 
 impl Scene {
-    pub fn new(camera: Camera, objects: Vec<Object>, skybox: Skybox) -> Scene {
+    pub fn new(objects: Vec<Object>, skybox: Skybox) -> Scene {
         let bvh = construct_bvh_aac(objects);
-        Scene { camera, skybox, bvh }
+        Scene { skybox, bvh }
     }
 
     pub fn find_intersection(&self, ray: Ray) -> Option<(Collision, Material)> {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -53,7 +53,11 @@ pub struct SceneDescription {
 }
 
 impl SceneDescription {
-    pub fn to_scene(&self) -> scene::Scene {
+    pub fn camera(&self) -> Camera {
+        self.camera.to_camera()
+    }
+
+    pub fn scene(&self) -> scene::Scene {
         let mut objects: Vec<scene::Object> = Vec::with_capacity(self.objects.len());
         let mut models: HashMap<String, Vec<geom::Shape>> = HashMap::with_capacity(self.models.len());
 
@@ -87,7 +91,7 @@ impl SceneDescription {
                 objects.push(scene::Object{ material: material.clone(), shape: shape.clone() });
             });
         });
-        scene::Scene::new(self.camera.to_camera(), objects, self.skybox.to_skybox())
+        scene::Scene::new(objects, self.skybox.to_skybox())
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -112,7 +112,7 @@ impl CameraDescription {
         let mut camera = Camera::new(
             self.image_width,
             self.image_height,
-            Box::new(CorrelatedMultiJitteredSampler::new(42, 16, 16)));
+            Box::new(CorrelatedMultiJitteredSampler::new(42, 4, 4)));
 
         camera.location = self.location.to_vector();
         camera.set_orientation(self.orientation.yaw, self.orientation.pitch, self.orientation.roll);

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use crate::camera::Camera;
 use crate::colour::Colour;
 use crate::matrix::Matrix3;
-use crate::sampling::CorrelatedMultiJitteredSampler;
 use crate::vector::Vector3;
 use crate::geom;
 use crate::material::{BasicMaterial, Material};
@@ -109,10 +108,7 @@ pub struct CameraDescription {
 
 impl CameraDescription {
     pub fn to_camera(&self) -> Camera {
-        let mut camera = Camera::new(
-            self.image_width,
-            self.image_height,
-            Box::new(CorrelatedMultiJitteredSampler::new(42, 4, 4)));
+        let mut camera = Camera::new(self.image_width, self.image_height);
 
         camera.location = self.location.to_vector();
         camera.set_orientation(self.orientation.yaw, self.orientation.pitch, self.orientation.roll);

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -1,0 +1,48 @@
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+
+pub struct Governer {
+    frames_per_second: u32,
+    frame_duration: Duration,
+    frame_times_q: VecDeque<Instant>,
+}
+
+impl Governer {
+    pub fn new(frames_per_second: u32) -> Governer {
+        let frame_ns: u64 = 1_000_000_000 / (frames_per_second as u64);
+        let frame_duration = Duration::from_nanos(frame_ns);
+        let mut frame_times_q: VecDeque<Instant> = VecDeque::new();
+        frame_times_q.push_back(Instant::now());
+
+        Governer {
+            frames_per_second,
+            frame_duration,
+            frame_times_q,
+        }
+    }
+
+    pub fn end_frame(&mut self) {
+        let num_frames_in_q = self.frame_times_q.len();
+        let expected_duration = self.frame_duration * (num_frames_in_q as u32);
+
+        let now = Instant::now();
+        let actual_duration = {
+            // Put this in a block so that oldest_frame_start gets dropped.
+            // It contains a reference to the queue, which we need to drop
+            // so we can modify it later.
+            let oldest_frame_start = self.frame_times_q.back().expect("Queue is not empty");
+            now.duration_since(*oldest_frame_start)
+        };
+
+        self.frame_times_q.push_front(now);
+
+        // Sleep if we're ahead.
+        match expected_duration.checked_sub(actual_duration) {
+            Some(remaining_time) => std::thread::sleep(remaining_time),
+            None => (),
+        }
+
+        self.frame_times_q.truncate(self.frames_per_second as usize);
+    }
+}

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,0 +1,53 @@
+use rand::Rng;
+
+use crate::colour::Colour;
+use crate::geom::Ray;
+use crate::scene::Scene;
+
+pub fn trace_ray(scene: &Scene, mut ray: Ray) -> Colour {
+    let mut throughput = Colour::WHITE;
+    let mut colour = Colour::BLACK;
+    let mut loops = 0;
+
+    loop {
+        if loops > 10 {
+            break;
+        }
+
+        let (collision, material) = if let Some((c, m)) = scene.find_intersection(ray) {
+            (c, m)
+        } else {
+            colour += throughput * scene.skybox.ambient_light(ray.direction * -1);
+            break;
+        };
+
+        let cos_out: f64 = ray.direction.dot(collision.normal);
+
+        let emittance = material.emittance(ray.direction * -1, cos_out);
+
+        let new_ray = Ray::new(
+            collision.location + collision.normal * 0.0001,  // Add the normal as a hack so it doesn't collide with the same object again.
+            material.sample_pdf(ray.direction * -1, collision.normal),
+        );
+
+        let pdf = material.weight_pdf(ray.direction * -1, new_ray.direction * -1, collision.normal);
+
+        let attenuation = material.brdf(ray.direction * -1, new_ray.direction * -1, collision.normal) / pdf;
+        throughput = throughput * attenuation;
+
+        colour += emittance * throughput;
+
+        // Chance for the material to eat the ray.
+        let survival_chance = throughput.max();
+        if rand::thread_rng().gen::<f64>() > survival_chance {
+            break;
+        }
+
+        throughput = throughput / survival_chance;
+
+        ray = new_ray;
+        loops += 1;
+    }
+
+    colour
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,0 +1,144 @@
+use std::sync::Arc;
+
+use crossbeam::channel;
+
+use crate::colour::Colour;
+use crate::scene::Scene;
+use crate::trace::trace_ray;
+
+pub struct Worker {
+    request_rx: channel::Receiver<RenderRequest>,
+    result_tx: channel::Sender<RenderResult>,
+    scene: Arc<Scene>,
+}
+
+impl Worker {
+    pub fn new(
+        request_rx: channel::Receiver<RenderRequest>,
+        result_tx: channel::Sender<RenderResult>,
+        scene: Arc<Scene>
+    ) -> Worker {
+        Worker{ request_rx, result_tx, scene }
+    }
+
+    pub fn run_forever(&self) {
+        self.request_rx.iter().for_each(|req| {
+            let mut camera = self.scene.camera.clone();
+            for _ in 0..req.num_samples {
+                camera.init_bundle();
+                let samples = req.iter_pixels().map(|(x, y)| {
+                    let (ray, weight) = camera.get_ray_for_pixel(x, y);
+                    let colour = trace_ray(&self.scene, ray) * weight;
+                    (x, y, colour)
+                }).collect();
+
+                match self.result_tx.send(RenderResult{ samples }) {
+                    Ok(_) => (),
+                    Err(err) => {
+                        panic!("Failed to send samples to main thread: {:?}", err);
+                    },
+                }
+            }
+        });
+    }
+}
+
+// API structs.
+#[derive(Clone, Copy, Debug)]
+pub struct RenderRequest {
+    pub top_left: (u32, u32),
+    pub bottom_right: (u32, u32),
+    pub num_samples: u32,
+}
+
+impl RenderRequest {
+    pub fn iter_pixels(self) -> PixelGridIter {
+        PixelGridIter::new(
+            self.top_left.0,
+            self.top_left.1,
+            self.bottom_right.0 - self.top_left.0 + 1,
+            self.bottom_right.1 - self.top_left.1 + 1,
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct PixelGridIter {
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+    pos: u32,
+}
+
+impl PixelGridIter {
+    pub fn new(x: u32, y: u32, w: u32, h: u32) -> PixelGridIter {
+        PixelGridIter{ x, y, w, h, pos: 0 }
+    }
+}
+
+impl Iterator for PixelGridIter {
+    type Item = (u32, u32);
+
+    fn next(&mut self) -> Option<(u32, u32)> {
+        if self.pos >= self.w * self.h {
+            None
+        } else {
+            let x_offset = self.pos % self.w;
+            let y_offset = self.pos / self.w;
+
+            let (x, y) = (self.x + x_offset, self.y + y_offset);
+
+            self.pos += 1;
+            Some((x, y))
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RenderResult {
+    pub samples: Vec<(u32, u32, Colour)>,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::worker;
+
+    #[test]
+    fn test_pixel_grid_iter_x() {
+        let mut grid = worker::PixelGridIter::new(0, 0, 3, 1);
+        assert_eq!(grid.next(), Some((0, 0)));
+        assert_eq!(grid.next(), Some((1, 0)));
+        assert_eq!(grid.next(), Some((2, 0)));
+        assert_eq!(grid.next(), None);
+    }
+
+    #[test]
+    fn test_pixel_grid_iter_y() {
+        let mut grid = worker::PixelGridIter::new(0, 0, 1, 3);
+        assert_eq!(grid.next(), Some((0, 0)));
+        assert_eq!(grid.next(), Some((0, 1)));
+        assert_eq!(grid.next(), Some((0, 2)));
+        assert_eq!(grid.next(), None);
+    }
+
+    #[test]
+    fn test_pixel_grid_iter_square() {
+        let mut grid = worker::PixelGridIter::new(0, 0, 2, 2);
+        assert_eq!(grid.next(), Some((0, 0)));
+        assert_eq!(grid.next(), Some((1, 0)));
+        assert_eq!(grid.next(), Some((0, 1)));
+        assert_eq!(grid.next(), Some((1, 1)));
+        assert_eq!(grid.next(), None);
+    }
+
+    #[test]
+    fn test_pixel_grid_iter_offset_square() {
+        let mut grid = worker::PixelGridIter::new(4, 4, 2, 2);
+        assert_eq!(grid.next(), Some((4, 4)));
+        assert_eq!(grid.next(), Some((5, 4)));
+        assert_eq!(grid.next(), Some((4, 5)));
+        assert_eq!(grid.next(), Some((5, 5)));
+        assert_eq!(grid.next(), None);
+    }
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -24,9 +24,9 @@ impl Worker {
         request_rx: channel::Receiver<RenderRequest>,
         result_tx: channel::Sender<RenderResult>,
         control_rx: channel::Receiver<ControlMessage>,
-        scene: Arc<Scene>
+        scene: Arc<Scene>,
+        camera: Camera,
     ) -> Worker {
-        let camera = scene.camera.clone();
         Worker{
             request_rx, result_tx, control_rx,
             scene,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use crossbeam::channel;
+use crossbeam::channel::select;
 
+use crate::camera::Camera;
 use crate::colour::Colour;
 use crate::scene::Scene;
 use crate::sampling::{CorrelatedMultiJitteredSampler, Disk, IntoPattern, Square};
@@ -10,48 +12,111 @@ use crate::trace::trace_ray;
 pub struct Worker {
     request_rx: channel::Receiver<RenderRequest>,
     result_tx: channel::Sender<RenderResult>,
+    control_rx: channel::Receiver<ControlMessage>,
     scene: Arc<Scene>,
+    camera: Camera,
+    epoch: u64,
+    is_running: bool,
 }
 
 impl Worker {
     pub fn new(
         request_rx: channel::Receiver<RenderRequest>,
         result_tx: channel::Sender<RenderResult>,
+        control_rx: channel::Receiver<ControlMessage>,
         scene: Arc<Scene>
     ) -> Worker {
-        Worker{ request_rx, result_tx, scene }
+        let camera = scene.camera.clone();
+        Worker{
+            request_rx, result_tx, control_rx,
+            scene,
+            camera,
+            epoch: 0,
+            is_running: true,
+        }
     }
 
-    pub fn run_forever(&self) {
-        self.request_rx.iter().for_each(|req| {
-            let mut camera = self.scene.camera.clone();
+    pub fn run_forever(&mut self) {
+        while self.is_running {
+            select! {
+                recv(self.request_rx) -> res => match res {
+                    Ok(req) => self.handle_render_req(req),
+                    Err(err) => panic!("Error when receiving render request: {}", err),
+                },
+                recv(self.control_rx) -> res => match res {
+                    Ok(msg) => self.handle_control_msg(msg),
+                    Err(err) => panic!("Error when receiving control message: {}", err),
+                },
+            }
+        }
+    }
 
-            let (m, n) = req.pattern_size;
-            let sensor_pattern = CorrelatedMultiJitteredSampler::random(m, n).pattern::<Square>();
-            let lens_pattern = CorrelatedMultiJitteredSampler::random(m, n).pattern::<Disk>();
-            let patterns = sensor_pattern.zip(lens_pattern);
+    fn handle_render_req(&self, req: RenderRequest) {
+        // Ignore if from a different epoch.
+        if req.epoch != self.epoch {
+            return;
+        }
 
-            patterns.for_each(|(sensor_sample, lens_sample)| {
-                let samples = req.iter_pixels().map(|(x, y)| {
-                    let (ray, weight) = camera.get_ray_for_pixel(x, y, sensor_sample, lens_sample);
-                    let colour = trace_ray(&self.scene, ray) * weight;
-                    (x, y, colour)
-                }).collect();
+        let (m, n) = req.pattern_size;
+        let sensor_pattern = CorrelatedMultiJitteredSampler::random(m, n).pattern::<Square>();
+        let lens_pattern = CorrelatedMultiJitteredSampler::random(m, n).pattern::<Disk>();
+        let patterns = sensor_pattern.zip(lens_pattern);
 
-                match self.result_tx.send(RenderResult{ samples }) {
-                    Ok(_) => (),
-                    Err(err) => {
-                        panic!("Failed to send samples to main thread: {}", err);
-                    },
-                }
-            });
+        patterns.for_each(|(sensor_sample, lens_sample)| {
+            let samples = req.iter_pixels().map(|(x, y)| {
+                let (ray, weight) = self.camera.get_ray_for_pixel(x, y, sensor_sample, lens_sample);
+                let colour = trace_ray(&self.scene, ray) * weight;
+                (x, y, colour)
+            }).collect();
+
+            match self.result_tx.send(RenderResult{ epoch: self.epoch, samples }) {
+                Ok(_) => (),
+                Err(err) => {
+                    panic!("Failed to send samples to main thread: {}", err);
+                },
+            }
+        });
+    }
+
+    fn handle_control_msg(&mut self, msg: ControlMessage) {
+        msg.commands.iter().for_each(|cmd| {
+            match cmd {
+                Command::Shutdown => self.is_running = false,
+                Command::SetEpoch(epoch) => self.epoch = *epoch,
+                Command::ReorientCamera(yaw, pitch, roll) => self.camera.set_orientation(*yaw, *pitch, *roll),
+            }
         });
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct ControlMessage {
+    pub commands: Vec<Command>,
+}
+
+impl ControlMessage {
+    pub fn new() -> ControlMessage {
+        ControlMessage{ commands: Vec::new() }
+    }
+
+    pub fn cmd(mut self, cmd: Command) -> ControlMessage {
+        self.commands.push(cmd);
+        self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Command {
+    Shutdown,
+    SetEpoch(u64),
+    ReorientCamera(f64, f64, f64),
+}
+
+
 // API structs.
 #[derive(Clone, Copy, Debug)]
 pub struct RenderRequest {
+    pub epoch: u64,
     pub top_left: (u32, u32),
     pub bottom_right: (u32, u32),
     pub pattern_size: (u32, u32),
@@ -103,6 +168,7 @@ impl Iterator for PixelGridIter {
 
 #[derive(Clone, Debug)]
 pub struct RenderResult {
+    pub epoch: u64,
     pub samples: Vec<(u32, u32, Colour)>,
 }
 


### PR DESCRIPTION
Rearchitected the renderer to no longer run 1 sample per pixel synchronously each frame.

Now the workers are long-lived threads, which receive requests to render certain parts of the scene from the driver.

This gains us a little performance over master, since the workers can keep working while the main thread is doing stuff like collecting the render results etc.

Also means the application itself can maintain a steady 60fps, making it much more responsive to input.