### PR TITLE
Fast preview and better controls

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -15,7 +15,7 @@ pub struct Camera {
     pub focal_length: f64,
     pub distance_from_lens: f64,
     pub aperture: f64,
-    rot: Matrix3,
+    pub rot: Matrix3,
     pub sensor_width: f64,
     pub sensor_height: f64,
     pub width: u32,
@@ -92,7 +92,11 @@ impl Camera {
         (Ray::new(origin, direction), weight)
     }
 
-    pub fn set_orientation(&mut self, yaw: f64, pitch: f64, roll: f64) {
-        self.rot = Matrix3::rotation(yaw, pitch, roll);
+    pub fn set_orientation(&mut self, orientation: Matrix3) {
+        self.rot = orientation;
+    }
+
+    pub fn set_position(&mut self, location: Vector3) {
+        self.location = location;
     }
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -46,11 +46,16 @@ impl Camera {
 
     pub fn get_ray_for_pixel(
         &self,
-        x: u32,
-        y: u32,
+        mut x: u32,
+        mut y: u32,
         point_on_square: (f64, f64),
         point_on_disk: (f64, f64)
     ) -> (Ray, f64) {
+        // The image on a camera lens is flipped, so reflect x and y so that
+        // we get the pixel that was actually asked for.
+        x = self.width - x - 1;
+        y = self.height - y - 1;
+        
         // We'll compute the outbound ray first in lens-space where the centre of 
         // the lens is at the origin.
         // Then transform into world space.

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -81,13 +81,14 @@ impl Camera {
 
         // this equation for ray direction precomputed by hand to collapse all the terms that go away.
         let dir = ((k * (p/v)) + l) * -1;
+        let norm_dir = dir.normed();
 
         // Now transform into world space.
         let origin = self.rot.clone() * l + self.location;
-        let direction = (self.rot.clone() * dir).normed();
+        let direction = self.rot.clone() * norm_dir;
 
         // Weight is d.n, but sinze n is just (0,0,1) we can shortcut.
-        let weight = direction.z;
+        let weight = norm_dir.z;
 
         (Ray::new(origin, direction), weight)
     }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,0 +1,49 @@
+use crate::camera::Image;
+use crate::matrix::Matrix3;
+use crate::renderer::Renderer;
+use crate::vector::Vector3;
+
+pub struct Controller {
+    renderer: Renderer,
+    location: Vector3,
+    orientation: Matrix3,
+}
+
+impl Controller {
+    pub fn new(renderer: Renderer, location: Vector3, orientation: Matrix3) -> Controller {
+        Controller{ renderer, location, orientation }
+    }
+
+    pub fn update(&mut self) {
+        self.renderer.fill_request_queue();
+        self.renderer.drain_result_queue();
+    }
+
+    pub fn render(&mut self) -> Image {
+        self.renderer.render()
+    }
+
+    pub fn move_camera(&mut self, x: f64, y: f64, z: f64) {
+        let movement = self.orientation * Vector3::new(x, y, z);
+        self.location = self.location + movement;
+        self.renderer.reposition_camera(self.location);
+    }
+
+    pub fn rotate(&mut self, yaw: f64, pitch: f64, roll: f64) {
+        let rot = Matrix3::rotation(yaw, pitch, roll);
+        self.orientation = self.orientation * rot;
+        self.renderer.reorient_camera(self.orientation);
+    }
+
+    pub fn reset(&mut self) {
+        self.renderer.reset();
+    }
+
+    pub fn shutdown(&mut self) {
+        self.renderer.shutdown();
+    }
+
+    pub fn num_rays_cast(&self) -> u64{
+        self.renderer.num_rays_cast()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,7 @@ fn main() {
     let frames_per_second: u32 = 60;
     let mut governer = timing::Governer::new(60);
 
+    renderer.reset();
     renderer.fill_request_queue();
     while is_running {
         renderer.drain_result_queue();
@@ -129,8 +130,8 @@ fn main() {
                    Some(Keycode::U) => roll += 0.1,
                    Some(Keycode::I) => pitch -= 0.1,
                    Some(Keycode::K) => pitch += 0.1,
-                   Some(Keycode::J) => yaw += 0.1,
-                   Some(Keycode::L) => yaw -= 0.1,
+                   Some(Keycode::J) => yaw -= 0.1,
+                   Some(Keycode::L) => yaw += 0.1,
                    _ => should_reset = false,
                 },
                 _ => should_reset = false,

--- a/src/pixels.rs
+++ b/src/pixels.rs
@@ -24,31 +24,52 @@ impl <T : Copy + ops::AddAssign<T> + ops::Div<u32, Output = T>> MeanVec<T> {
     pub fn get(&self, ix: usize) -> T {
         self.sums[ix] / self.counts[ix]
     }
+
+    pub fn count(&self, ix: usize) -> u32 {
+        self.counts[ix]
+    }
 }
 
 pub struct Estimator {
     width: usize,
     height: usize,
+    preview_grid_size: usize,
     means: MeanVec<Colour>,
 }
 
 impl Estimator {
-    pub fn new(width: usize, height: usize) -> Estimator {
+    pub fn new(width: usize, height: usize, preview_grid_size: usize) -> Estimator {
         Estimator {
             width, height,
+            preview_grid_size,
             means: MeanVec::new(width * height, Colour::BLACK),
         }
     }
 
     pub fn update_pixel(&mut self, x: usize, y: usize, colour: Colour) {
-        let reflected_y = self.height - y - 1;
-        self.means.update(x + (reflected_y * self.width), colour);
+        self.means.update(x + y * self.width, colour);
     }
 
     pub fn render(&self) -> Image {
         let mut buffer = Vec::with_capacity(self.width * self.height);
         for ix in 0 .. self.width * self.height {
-            buffer.push(self.means.get(ix));
+            if self.means.count(ix) == 0 {
+                // No samples, fill using preview grid.
+                let x = ix % self.width;
+                let y = ix / self.width;
+                let grid_size = self.preview_grid_size;
+
+                if x % grid_size == 0 && y % grid_size == 0 {
+                    buffer.push(self.means.get(ix));
+                } else {
+                    let grid_x = x - (x % grid_size);
+                    let grid_y = y - (y % grid_size);
+                    let grid_ix = grid_x + grid_y * self.width;
+                    buffer.push(self.means.get(grid_ix));
+                }
+            } else {
+                buffer.push(self.means.get(ix));
+            }
         }
         Image {
             width: self.width as u32,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -4,8 +4,10 @@ use crossbeam::channel;
 use threadpool::ThreadPool;
 
 use crate::camera::{Camera, Image};
+use crate::matrix::Matrix3;
 use crate::pixels::Estimator;
 use crate::scene::Scene;
+use crate::vector::Vector3;
 use crate::worker;
 
 const PREVIEW_GRID_SIZE: usize = 4;
@@ -107,10 +109,19 @@ impl Renderer {
         }
     }
 
-    pub fn reorient_camera(&mut self, yaw: f64, pitch: f64, roll: f64) {
+    pub fn reorient_camera(&mut self, orientation: Matrix3) {
         let epoch = self.new_epoch();
         self.broadcast_command(worker::ControlMessage::new()
-            .cmd(worker::Command::ReorientCamera(yaw, pitch, roll))
+            .cmd(worker::Command::ReorientCamera(orientation))
+            .cmd(worker::Command::SetEpoch(epoch))
+        );
+        self.request_preview();
+    }
+
+    pub fn reposition_camera(&mut self, location: Vector3) {
+        let epoch = self.new_epoch();
+        self.broadcast_command(worker::ControlMessage::new()
+            .cmd(worker::Command::RepositionCamera(location))
             .cmd(worker::Command::SetEpoch(epoch))
         );
         self.request_preview();

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -115,7 +115,8 @@ impl CameraDescription {
         let mut camera = Camera::new(self.image_width, self.image_height);
 
         camera.location = self.location.to_vector();
-        camera.set_orientation(self.orientation.yaw, self.orientation.pitch, self.orientation.roll);
+        let orientation = Matrix3::rotation(self.orientation.yaw, self.orientation.pitch, self.orientation.roll);
+        camera.set_orientation(orientation);
 
         camera.sensor_width = self.sensor_width;
         camera.sensor_height = self.sensor_height;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5,9 +5,11 @@ use crossbeam::channel::select;
 
 use crate::camera::Camera;
 use crate::colour::Colour;
+use crate::matrix::Matrix3;
 use crate::scene::Scene;
 use crate::sampling::{CorrelatedMultiJitteredSampler, Disk, IntoPattern, Square};
 use crate::trace::trace_ray;
+use crate::vector::Vector3;
 
 pub struct Worker {
     request_rx: channel::Receiver<RenderRequest>,
@@ -89,7 +91,8 @@ impl Worker {
             match cmd {
                 Command::Shutdown => self.is_running = false,
                 Command::SetEpoch(epoch) => self.epoch = *epoch,
-                Command::ReorientCamera(yaw, pitch, roll) => self.camera.set_orientation(*yaw, *pitch, *roll),
+                Command::ReorientCamera(orientation) => self.camera.set_orientation(*orientation),
+                Command::RepositionCamera(location) => self.camera.set_position(*location),
             }
         });
         self.process_buffered_reqs();
@@ -124,7 +127,8 @@ impl ControlMessage {
 pub enum Command {
     Shutdown,
     SetEpoch(u64),
-    ReorientCamera(f64, f64, f64),
+    ReorientCamera(Matrix3),
+    RepositionCamera(Vector3),
 }
 
 


### PR DESCRIPTION
Fast preview renders a subset of pixels to get a preview as fast as possible after changing camera parameters.

Controls are now relative to current position/orientation which is much more intuitive.

In action:
![teapot-control](https://user-images.githubusercontent.com/3620166/80898677-1bfa4a80-8d41-11ea-93d9-95cfe4f9699e.gif)