### PR TITLE
Rewrite material models

### DIFF
--- a/scenes/bunny.yml
+++ b/scenes/bunny.yml
@@ -22,7 +22,7 @@ models:
 
 lights:
   - colour: { r: 0.8, g: 0.8, b: 1.0 }
-    intensity: 250.0
+    intensity: 1000.0
     geometry:
       type: Sphere
       center: { x: 5.0, y: 10.0, z: -5.0 }
@@ -36,42 +36,24 @@ objects:
       rotation: { pitch: 1.9, yaw: 0.0, roll: 0.0 }
       scale: 20.0
     material:
-      type: Fresnel
-      refractive_index: 5.5
-      diffuse:
-        type: Lambertian
-        albedo: { r: 0.8, g: 0.3, b: 0.3 }
-      specular: 
-        type: CookTorrance
-        albedo: { r: 1.0, g: 1.0, b: 1.0 }
-        roughness: 0.1
+      type: Gloss
+      albedo: { r: 0.8, g: 0.3, b: 0.3 }
+      reflectance: 0.04
 
   - shape:
       type: Sphere
       radius: 1.0
       center: { x: 3.0, y: 1.0, z: 3.0 }
     material:
-      type: Fresnel
-      refractive_index: 5.5
-      diffuse:
-        type: Lambertian
-        albedo: { r: 0.8, g: 0.8, b: 1.0 }
-      specular: 
-        type: CookTorrance
-        albedo: { r: 1.0, g: 1.0, b: 1.0 }
-        roughness: 0.001
+      type: Gloss
+      albedo: { r: 0.3, g: 0.3, b: 0.8 }
+      reflectance: 0.8
 
   - shape:
       type: Sphere
       radius: 1000000.0
       center: { x: 0.0, y: -1000000.0, z: 0.0 }
     material:
-      type: Fresnel
-      refractive_index: 3.5
-      diffuse:
-        type: Lambertian
-        albedo: { r: 0.2, g: 0.2, b: 0.2 }
-      specular: 
-        type: CookTorrance
-        albedo: { r: 1.0, g: 1.0, b: 1.0 }
-        roughness: 0.001
+      type: Gloss
+      albedo: { r: 0.2, g: 0.2, b: 0.2 }
+      reflectance: 0.04

--- a/scenes/bunny.yml
+++ b/scenes/bunny.yml
@@ -38,7 +38,8 @@ objects:
     material:
       type: Gloss
       albedo: { r: 0.8, g: 0.3, b: 0.3 }
-      reflectance: 0.04
+      reflectance: 0.8
+      metalness: 1.0
 
   - shape:
       type: Sphere
@@ -47,7 +48,8 @@ objects:
     material:
       type: Gloss
       albedo: { r: 0.3, g: 0.3, b: 0.8 }
-      reflectance: 0.8
+      reflectance: 0.04
+      metalness: 0.0
 
   - shape:
       type: Sphere
@@ -57,3 +59,4 @@ objects:
       type: Gloss
       albedo: { r: 0.2, g: 0.2, b: 0.2 }
       reflectance: 0.04
+      metalness: 0.0

--- a/scenes/bunny.yml
+++ b/scenes/bunny.yml
@@ -22,7 +22,7 @@ models:
 
 lights:
   - colour: { r: 0.8, g: 0.8, b: 1.0 }
-    intensity: 1000.0
+    intensity: 100.0
     geometry:
       type: Sphere
       center: { x: 5.0, y: 10.0, z: -5.0 }
@@ -57,6 +57,17 @@ objects:
       center: { x: 0.0, y: -1000000.0, z: 0.0 }
     material:
       type: Gloss
-      albedo: { r: 0.2, g: 0.2, b: 0.2 }
+      albedo: { r: 0.5, g: 0.5, b: 0.5 }
       reflectance: 0.04
       metalness: 0.0
+
+  - shape:
+      type: Sphere
+      radius: 1000000.0
+      center: { x: 0.0, y: 0.0, z: 1000010.0 }
+    material:
+      type: Gloss
+      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      reflectance: 0.04
+      metalness: 0.0
+

--- a/scenes/bunny.yml
+++ b/scenes/bunny.yml
@@ -22,7 +22,7 @@ models:
 
 lights:
   - colour: { r: 0.8, g: 0.8, b: 1.0 }
-    intensity: 100.0
+    intensity: 200.0
     geometry:
       type: Sphere
       center: { x: 5.0, y: 10.0, z: -5.0 }

--- a/scenes/dragon.yml
+++ b/scenes/dragon.yml
@@ -23,11 +23,11 @@ models:
     file: "./scenes/objects/teapot.obj"
 
 lights:
-  - colour: { r: 0.8, g: 0.8, b: 0.8 }
-    intensity: 2000.0
+  - colour: { r: 1.0, g: 1.0, b: 1.0 }
+    intensity: 2500.0
     geometry:
       type: Sphere
-      center: { x: 10.0, y: 20.0, z: -5.0 }
+      center: { x: 5.0, y: 20.0, z: -3.0 }
       radius: 5.0
 
 objects:
@@ -38,27 +38,15 @@ objects:
       rotation: { pitch: 3.1, yaw: 0.0, roll: 0.0 }
       scale: 50.0
     material:
-      type: Fresnel
-      refractive_index: 5.5
-      diffuse:
-        type: Lambertian
-        albedo: { r: 0.3, g: 0.6, b: 0.3 }
-      specular: 
-        type: CookTorrance
-        albedo: { r: 1.0, g: 1.0, b: 1.0 }
-        roughness: 0.02
+      type: Gloss
+      albedo: { r: 0.3, g: 0.3, b: 0.8 }
+      reflectance: 0.04
 
   - shape:
       type: Sphere
       radius: 1000000.0
       center: { x: 0.0, y: -1000000.0, z: 0.0 }
     material:
-      type: Fresnel
-      refractive_index: 3.5
-      diffuse:
-        type: Lambertian
-        albedo: { r: 0.2, g: 0.2, b: 0.2 }
-      specular: 
-        type: CookTorrance
-        albedo: { r: 1.0, g: 1.0, b: 1.0 }
-        roughness: 0.001
+      type: Gloss
+      albedo: { r: 0.2, g: 0.2, b: 0.2 }
+      reflectance: 0.04

--- a/scenes/dragon.yml
+++ b/scenes/dragon.yml
@@ -1,8 +1,8 @@
 camera:
   image_width: 720
   image_height: 480
-  location: { x: 3.0, y: 15.0, z: -15.0 }
-  orientation: { pitch: 0.65, yaw: -0.15, roll: 0.0 }
+  location: { x: 0.0, y: 10.0, z: -17.0 }
+  orientation: { pitch: 0.35, yaw: 0.0, roll: 0.0 }
   sensor_width: 0.036
   sensor_height: 0.024
   focal_length: 0.05
@@ -11,36 +11,33 @@ camera:
 
 skybox:
   type: Gradient
-  overhead_colour: { r: 0.1, g: 0.1, b: 0.1 }
+  overhead_colour: { r: 0.0, g: 0.0, b: 0.0 }
   horizon_colour: { r: 0.0, g: 0.0, b: 0.0 }
 
 models:
-  bunny:
-    file: "./scenes/objects/bunny.obj"
   dragon:
     file: "./dragon_recon/dragon_vrip.ply"
-  teapot:
-    file: "./scenes/objects/teapot.obj"
 
 lights:
-  - colour: { r: 1.0, g: 1.0, b: 1.0 }
-    intensity: 2500.0
+  - colour: { r: 1.0, g: 1.0, b: 0.95 }
+    intensity: 2000.0
     geometry:
       type: Sphere
-      center: { x: 5.0, y: 20.0, z: -3.0 }
-      radius: 5.0
+      center: { x: 0.0, y: 20.0, z: 0.0 }
+      radius: 3.0
 
 objects:
   - shape:
       type: Mesh
       model: dragon
-      translation: { x: 0.0, y: -2.5, z: 0.0 }
+      translation: { x: 0.0, y: -2.2, z: 0.0 }
       rotation: { pitch: 3.1, yaw: 0.0, roll: 0.0 }
-      scale: 50.0
+      scale: 40.0
     material:
       type: Gloss
-      albedo: { r: 0.3, g: 0.3, b: 0.8 }
-      reflectance: 0.04
+      albedo: { r: 1.00, g: 0.85, b: 0.57 }
+      reflectance: 0.8
+      metalness: 1.0
 
   - shape:
       type: Sphere
@@ -48,5 +45,56 @@ objects:
       center: { x: 0.0, y: -1000000.0, z: 0.0 }
     material:
       type: Gloss
-      albedo: { r: 0.2, g: 0.2, b: 0.2 }
+      albedo: { r: 0.5, g: 0.5, b: 0.5 }
       reflectance: 0.04
+      metalness: 0.0
+
+  - shape:
+      type: Sphere
+      radius: 1000000.0
+      center: { x: 0.0, y: 1000020.0, z: 0.0 }
+    material:
+      type: Gloss
+      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      reflectance: 0.04
+      metalness: 0.0
+
+  - shape:
+      type: Sphere
+      radius: 1000000.0
+      center: { x: 0.0, y: 0.0, z: 1000010.0 }
+    material:
+      type: Gloss
+      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      reflectance: 0.04
+      metalness: 0.0
+
+  - shape:
+      type: Sphere
+      radius: 1000000.0
+      center: { x: 0.0, y: 0.0, z: -1000020.0 }
+    material:
+      type: Gloss
+      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      reflectance: 0.04
+      metalness: 0.0
+
+  - shape:
+      type: Sphere
+      radius: 1000000.0
+      center: { x: -1000010.0, y: 0.0, z: 0.0 }
+    material:
+      type: Gloss
+      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      reflectance: 0.04
+      metalness: 0.0
+
+  - shape:
+      type: Sphere
+      radius: 1000000.0
+      center: { x: 1000010.0, y: 0.0, z: 0.0 }
+    material:
+      type: Gloss
+      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      reflectance: 0.04
+      metalness: 0.0

--- a/scenes/dragon.yml
+++ b/scenes/dragon.yml
@@ -5,9 +5,9 @@ camera:
   orientation: { pitch: 0.35, yaw: 0.0, roll: 0.0 }
   sensor_width: 0.036
   sensor_height: 0.024
-  focal_length: 0.05
+  focal_length: 0.043
   focus_distance: 15.0
-  aperture: 8.0
+  aperture: 2.0
 
 skybox:
   type: Gradient
@@ -35,7 +35,7 @@ objects:
       scale: 40.0
     material:
       type: Gloss
-      albedo: { r: 1.00, g: 0.85, b: 0.57 }
+      albedo: { r: 0.95, g: 0.80, b: 0.30 }
       reflectance: 1.0
       metalness: 1.0
 
@@ -44,57 +44,45 @@ objects:
       radius: 1000000.0
       center: { x: 0.0, y: -1000000.0, z: 0.0 }
     material:
-      type: Gloss
+      type: Lambertian
       albedo: { r: 0.5, g: 0.5, b: 0.5 }
-      reflectance: 0.04
-      metalness: 0.0
 
   - shape:
       type: Sphere
       radius: 1000000.0
       center: { x: 0.0, y: 1000020.0, z: 0.0 }
     material:
-      type: Gloss
+      type: Lambertian
       albedo: { r: 0.5, g: 0.5, b: 0.5 }
-      reflectance: 0.04
-      metalness: 0.0
 
   - shape:
       type: Sphere
       radius: 1000000.0
       center: { x: 0.0, y: 0.0, z: 1000010.0 }
     material:
-      type: Gloss
+      type: Lambertian
       albedo: { r: 0.5, g: 0.5, b: 0.5 }
-      reflectance: 0.04
-      metalness: 0.0
 
   - shape:
       type: Sphere
       radius: 1000000.0
       center: { x: 0.0, y: 0.0, z: -1000020.0 }
     material:
-      type: Gloss
+      type: Lambertian
       albedo: { r: 0.5, g: 0.5, b: 0.5 }
-      reflectance: 0.04
-      metalness: 0.0
 
   - shape:
       type: Sphere
       radius: 1000000.0
       center: { x: -1000010.0, y: 0.0, z: 0.0 }
     material:
-      type: Gloss
+      type: Lambertian
       albedo: { r: 0.5, g: 0.5, b: 0.5 }
-      reflectance: 0.04
-      metalness: 0.0
 
   - shape:
       type: Sphere
       radius: 1000000.0
       center: { x: 1000010.0, y: 0.0, z: 0.0 }
     material:
-      type: Gloss
+      type: Lambertian
       albedo: { r: 0.5, g: 0.5, b: 0.5 }
-      reflectance: 0.04
-      metalness: 0.0

--- a/scenes/dragon.yml
+++ b/scenes/dragon.yml
@@ -20,11 +20,11 @@ models:
 
 lights:
   - colour: { r: 1.0, g: 1.0, b: 0.95 }
-    intensity: 2000.0
+    intensity: 200.0
     geometry:
       type: Sphere
       center: { x: 0.0, y: 20.0, z: 0.0 }
-      radius: 3.0
+      radius: 1.0
 
 objects:
   - shape:
@@ -36,7 +36,7 @@ objects:
     material:
       type: Gloss
       albedo: { r: 1.00, g: 0.85, b: 0.57 }
-      reflectance: 0.8
+      reflectance: 1.0
       metalness: 1.0
 
   - shape:

--- a/scenes/dragon.yml
+++ b/scenes/dragon.yml
@@ -19,7 +19,7 @@ models:
     file: "./dragon_recon/dragon_vrip.ply"
 
 lights:
-  - colour: { r: 1.0, g: 1.0, b: 0.95 }
+  - colour: { r: 1.0, g: 1.0, b: 1.0 }
     intensity: 200.0
     geometry:
       type: Sphere
@@ -35,7 +35,7 @@ objects:
       scale: 40.0
     material:
       type: Gloss
-      albedo: { r: 0.95, g: 0.80, b: 0.30 }
+      albedo: { r: 0.92, g: 0.78, b: 0.40 }
       reflectance: 1.0
       metalness: 1.0
 

--- a/scenes/dragon.yml
+++ b/scenes/dragon.yml
@@ -35,9 +35,9 @@ objects:
       scale: 40.0
     material:
       type: Gloss
-      albedo: { r: 0.92, g: 0.78, b: 0.40 }
-      reflectance: 1.0
-      metalness: 1.0
+      albedo: { r: 0.30, g: 0.80, b: 0.30 }
+      reflectance: 0.05
+      metalness: 0.0
 
   - shape:
       type: Sphere

--- a/src/colour.rs
+++ b/src/colour.rs
@@ -53,7 +53,17 @@ impl Colour {
         }
     }
 
-    fn component_to_byte(x: f64) -> u8 {
+    pub fn check(self) {
+        if self.r < 0.0 || self.g < 0.0 || self.b < 0.0 {
+            panic!("Invalid colour! {:?}", self);
+        }
+    }
+
+    fn component_to_byte(mut x: f64) -> u8 {
+        // Gamma correction.
+        const GAMMA: f64 = 0.45;
+        x = x.powf(GAMMA);
+
         if x >= 1.0 {
             255
         } else if x <= 0.0 {

--- a/src/colour.rs
+++ b/src/colour.rs
@@ -54,13 +54,12 @@ impl Colour {
     }
 
     fn component_to_byte(x: f64) -> u8 {
-        let rounded = (x * 256.0) as i16;
-        if rounded >= 256 {
+        if x >= 1.0 {
             255
-        } else if rounded <= 0 {
+        } else if x <= 0.0 {
             0
         } else {
-            rounded as u8
+            (x * 256.0) as u8
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ fn main() {
 
     let location = camera.location;
     let orientation = camera.rot;
-    let renderer = Renderer::new(camera, Arc::new(scene), 4);
+    let renderer = Renderer::new(camera, Arc::new(scene), 8);
     let mut controller = Controller::new(renderer, location, orientation);
 
     let mut texture_buffer: Vec<u8> = vec![0; (width * height * 3) as usize];

--- a/src/material.rs
+++ b/src/material.rs
@@ -166,8 +166,8 @@ impl LambertianMaterial {
 }
 
 impl MaterialInterface for LambertianMaterial {
-    fn weight_pdf(&self, vec_out: Vector3, _vec_in: Vector3, normal: Vector3) -> f64 {
-        vec_out.dot(normal) / PI
+    fn weight_pdf(&self, _vec_out: Vector3, vec_in: Vector3, normal: Vector3) -> f64 {
+        normal.dot(vec_in * -1) / PI
     }
 
     fn sample_pdf(&self, _vec_out: Vector3, normal: Vector3) -> Vector3 {
@@ -254,14 +254,14 @@ impl GlossMaterial {
         if is_specular {
             let direction = self.mirror.sample_pdf(vec_out, normal);
             let vec_in = direction * -1.0;
-            let pdf = self.mirror.weight_pdf(vec_in, vec_out, normal);
+            let pdf = self.mirror.weight_pdf(vec_out, vec_in, normal);
             let brdf = self.lambertian.albedo * self.metalness + Colour::WHITE * (1.0 - self.metalness);
             (direction, pdf * r, brdf * r, is_specular)
         } else {
             let direction = self.lambertian.sample_pdf(vec_out, normal);
             let vec_in = direction * -1.0;
-            let pdf = self.lambertian.weight_pdf(vec_in, vec_out, normal);
-            let brdf = self.lambertian.brdf(vec_in, vec_out, normal) * (1.0 - self.metalness);
+            let pdf = self.lambertian.weight_pdf(vec_out, vec_in, normal);
+            let brdf = self.lambertian.brdf(vec_out, vec_in, normal) * (1.0 - self.metalness);
             (direction, pdf * (1.0 - r), brdf * (1.0 - r), is_specular)
         }
     }

--- a/src/material.rs
+++ b/src/material.rs
@@ -4,6 +4,7 @@ use rand;
 use rand::Rng;
 
 use crate::colour::Colour;
+use crate::geom;
 use crate::vector::Vector3;
 
 
@@ -171,19 +172,10 @@ impl MaterialInterface for LambertianMaterial {
     }
 
     fn sample_pdf(&self, _vec_out: Vector3, normal: Vector3) -> Vector3 {
-        let mut rng = rand::thread_rng();
-        let seed = rng.gen::<f64>();  // between 0 and 1.
-
-        let r = seed.sqrt();
-        let theta = rng.gen::<f64>() * PI * 2.0;
-        let x = r * theta.cos();
-        let y = r * theta.sin();
-        let z = (1.0 - x * x - y * y).sqrt();
-
-        let random_direction = Vector3::new(x, y, z);
+        let random_direction = geom::cosine_sample_hemisphere();
 
         let (i, j, k) = normal.form_basis();
-        let world_direction = to_basis(random_direction, i, j, k);
+        let world_direction = geom::switch_basis(random_direction, i, j, k);
 
         world_direction.normed()
     }
@@ -429,7 +421,7 @@ impl MaterialInterface for CookTorranceMaterial {
         }
 
         let (i, j, k) = normal.form_basis();
-        let world_facet_normal = to_basis(facet_normal, i, j, k).normed();
+        let world_facet_normal = geom::switch_basis(facet_normal, i, j, k).normed();
 
         let tmp = world_facet_normal.dot(normal);
         if tmp < 0.0 {
@@ -463,9 +455,5 @@ impl MaterialInterface for CookTorranceMaterial {
         // Specular component.
         self.albedo * (d * g) / (4.0 * ndv * ndl)
     }
-}
-
-fn to_basis(v: Vector3, i: Vector3, j: Vector3, k: Vector3) -> Vector3 {
-    i* v.x + j * v.y + k * v.z
 }
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -65,6 +65,7 @@ impl Material {
 
     pub fn sample(&self, vec_out: Vector3, normal: Vector3) -> (Vector3, f64, Colour, bool) {
         match self {
+            Material::Lambertian(mat) => mat.sample(vec_out, normal),
             Material::Gloss(mat) => mat.sample(vec_out, normal),
             _ => panic!("Not implemented"),
         }
@@ -155,6 +156,15 @@ pub struct LambertianMaterial {
     emittance: Colour,
 }
 
+impl LambertianMaterial {
+    pub fn sample(&self, vec_out: Vector3, normal: Vector3) -> (Vector3, f64, Colour, bool) {
+        let direction = self.sample_pdf(vec_out, normal);
+        let pdf = self.weight_pdf(vec_out, direction * -1, normal);
+        let brdf = self.brdf(vec_out, direction * -1, normal);
+        (direction, pdf, brdf, false)
+    }
+}
+
 impl MaterialInterface for LambertianMaterial {
     fn weight_pdf(&self, vec_out: Vector3, _vec_in: Vector3, normal: Vector3) -> f64 {
         vec_out.dot(normal) / PI
@@ -182,8 +192,8 @@ impl MaterialInterface for LambertianMaterial {
         self.emittance
     }
 
-    fn brdf(&self, vec_out: Vector3, _vec_in: Vector3, normal: Vector3) -> Colour {
-        self.albedo * vec_out.dot(normal) / PI
+    fn brdf(&self, _vec_out: Vector3, vec_in: Vector3, normal: Vector3) -> Colour {
+        self.albedo * normal.dot(vec_in * -1) / PI
     }
 }
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -164,30 +164,26 @@ impl MaterialInterface for LambertianMaterial {
         let mut rng = rand::thread_rng();
         let seed = rng.gen::<f64>();  // between 0 and 1.
 
-        let sin2_theta = seed;
-        let cos2_theta = 1.0 - sin2_theta;
-        let cos_theta = cos2_theta.sqrt();
-        let sin_theta = sin2_theta.sqrt();
-        let orientation = rng.gen::<f64>() * PI * 2.0;
+        let r = seed.sqrt();
+        let theta = rng.gen::<f64>() * PI * 2.0;
+        let x = r * theta.cos();
+        let y = r * theta.sin();
+        let z = (1.0 - x * x - y * y).sqrt();
 
-        let random_direction = Vector3::new(
-            sin_theta * orientation.cos(),
-            cos_theta,
-            sin_theta * orientation.sin(),
-            );
+        let random_direction = Vector3::new(x, y, z);
 
         let (i, j, k) = normal.form_basis();
         let world_direction = to_basis(random_direction, i, j, k);
 
-        world_direction
+        world_direction.normed()
     }
 
     fn emittance(&self, _vec_out: Vector3, _cos_out: f64) -> Colour {
         self.emittance
     }
 
-    fn brdf(&self, _vec_out: Vector3, _vec_in: Vector3, _normal: Vector3) -> Colour {
-        self.albedo / PI
+    fn brdf(&self, vec_out: Vector3, _vec_in: Vector3, normal: Vector3) -> Colour {
+        self.albedo * vec_out.dot(normal) / PI
     }
 }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -100,7 +100,7 @@ impl Renderer {
 
             self.num_rays_cast += result.samples.len() as u64;
             result.samples.iter().for_each(|(x, y, colour)| {
-                self.estimator.update_pixel(*x as usize, *y as usize, colour.clamped());
+                self.estimator.update_pixel(*x as usize, *y as usize, *colour);
             });
         });
 

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -49,10 +49,10 @@ impl Light {
         EntityID::Light(self.id)
     }
 
-    pub fn random_point(&self) -> Vector3 {
+    pub fn sample(&self, from: Vector3) -> (Vector3, f64) {
         match self.geometry {
-            LightGeometry::Point(v) => v,
-            LightGeometry::Area(p) => p.random_point(),
+            LightGeometry::Point(v) => (v, 1.0),
+            LightGeometry::Area(p) => p.sample(from),
         }
     }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -15,6 +15,21 @@ pub enum EntityID {
 }
 
 #[derive(Clone)]
+pub enum Entity {
+    Object(Object),
+    Light(Light),
+}
+
+impl Entity {
+    pub fn id(self) -> EntityID {
+        match self {
+            Entity::Object(o) => EntityID::Object(o.id),
+            Entity::Light(l) => EntityID::Light(l.id),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct Object {
     pub id: usize,
     pub geometry: Geometry,
@@ -30,6 +45,10 @@ pub struct Light {
 }
 
 impl Light {
+    pub fn entity_id(&self) -> EntityID {
+        EntityID::Light(self.id)
+    }
+
     pub fn random_point(&self) -> Vector3 {
         match self.geometry {
             LightGeometry::Point(v) => v,
@@ -94,26 +113,39 @@ pub struct Scene {
 
 impl Scene {
     pub fn new(model_library: ModelLibrary, objects: Vec<Object>, lights: Vec<Light>, skybox: Skybox) -> Scene {
-        let primitive_geometry = objects.iter()
+        let object_primitives = objects.iter()
             .map(|o| {
                 let id = o.id;
-                let mut primitives = match o.geometry {
+                let primitives = match o.geometry {
                     Geometry::Primitive(p) => vec![p],
                     Geometry::Mesh(ref m) => m.primitives(&model_library),
                 };
-                primitives.drain(..).map(move|p| (p, EntityID::Object(id))).collect()
+                primitives.into_iter().map(move|p| (p, EntityID::Object(id))).collect()
             })
-            .flat_map(|items: Vec<(Primitive, EntityID)>| { items.into_iter() })
-            .collect();
+            .flat_map(|items: Vec<(Primitive, EntityID)>| { items.into_iter() });
+
+        let light_primitives = lights.iter()
+            .map(|l| {
+                let id = l.id;
+                let primitives = match l.geometry {
+                    LightGeometry::Point(_) => vec![],
+                    LightGeometry::Area(primitive) => std::iter::once(primitive).collect(),
+                };
+                primitives.into_iter().map(move|p| (p, EntityID::Light(id))).collect()
+            })
+            .flat_map(|items: Vec<(Primitive, EntityID)>| { items.into_iter() });
+
+        let primitive_geometry = object_primitives.chain(light_primitives).collect();
+
         let bvh = construct_bvh_aac(primitive_geometry);
         Scene { skybox, objects, lights, bvh }
     }
 
-    pub fn find_intersection(&self, ray: Ray) -> Option<(Collision, Material)> {
+    pub fn find_intersection(&self, ray: Ray) -> Option<(Collision, Entity)> {
         self.bvh.find_intersection(ray).map(|(col, entity)| {
             match entity {
-                EntityID::Object(id) => Some((col, self.objects[*id].material)),
-                _ => None,
+                EntityID::Object(id) => Some((col, Entity::Object(self.objects[*id].clone()))),
+                EntityID::Light(id) => Some((col, Entity::Light(self.lights[*id].clone()))),
             }
         }).flatten()
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -239,7 +239,7 @@ impl From<&MaterialDescription> for Material {
     fn from(desc: &MaterialDescription) -> Material {
         match desc {
             MaterialDescription::Lambertian(mat) => Material::lambertian(mat.albedo.to_colour(), Colour::BLACK),
-            MaterialDescription::Gloss(mat) => Material::gloss(mat.albedo.to_colour(), mat.reflectance),
+            MaterialDescription::Gloss(mat) => Material::gloss(mat.albedo.to_colour(), mat.reflectance, mat.metalness),
             MaterialDescription::Mirror(_mat) => Material::mirror(),
             MaterialDescription::CookTorrance(mat) => Material::cook_torrance(mat.albedo.to_colour(), mat.roughness),
             MaterialDescription::Fresnel(mat) => 
@@ -256,7 +256,7 @@ impl From<BasicMaterialDescription> for BasicMaterial {
     fn from(desc: BasicMaterialDescription) -> BasicMaterial {
         match desc {
             BasicMaterialDescription::Lambertian(mat) => Material::lambertian(mat.albedo.to_colour(), Colour::BLACK).to_basic(),
-            BasicMaterialDescription::Gloss(mat) => Material::gloss(mat.albedo.to_colour(), mat.reflectance).to_basic(),
+            BasicMaterialDescription::Gloss(mat) => Material::gloss(mat.albedo.to_colour(), mat.reflectance, mat.metalness).to_basic(),
             BasicMaterialDescription::Mirror(_mat) => Material::mirror().to_basic(),
             BasicMaterialDescription::CookTorrance(mat) => Material::cook_torrance(mat.albedo.to_colour(), mat.roughness).to_basic(),
         }
@@ -272,6 +272,7 @@ pub struct LambertianMaterialDescription {
 pub struct GlossMaterialDescription {
     pub albedo: ColourDescription,
     pub reflectance: f64,
+    pub metalness: f64,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]

--- a/src/stress.rs
+++ b/src/stress.rs
@@ -47,6 +47,7 @@ fn random_material() -> serde::MaterialDescription {
         0 => serde::MaterialDescription::Gloss(serde::GlossMaterialDescription{
             albedo: random_colour(),
             reflectance: 1.0 + rng.gen::<f64>() * 2.0,
+            metalness: 0.0,
         }),
         1 => serde::MaterialDescription::Lambertian(serde::LambertianMaterialDescription{
             albedo: random_colour(),

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -2,20 +2,21 @@ use rand::Rng;
 
 use crate::colour::Colour;
 use crate::geom::Ray;
-use crate::scene::Scene;
+use crate::scene::{Entity, Scene};
 
 pub fn trace_ray(scene: &Scene, mut ray: Ray) -> Colour {
     let mut throughput = Colour::WHITE;
     let mut colour = Colour::BLACK;
     let mut loops = 0;
+    let mut last_bounce_specular = true;
 
     loop {
         if loops > 10 {
             break;
         }
 
-        let (collision, material) = if let Some((c, m)) = scene.find_intersection(ray) {
-            (c, m)
+        let (collision, entity) = if let Some((c, e)) = scene.find_intersection(ray) {
+            (c, e)
         } else {
             colour += throughput * scene.skybox.ambient_light(ray.direction * -1);
             break;
@@ -23,62 +24,77 @@ pub fn trace_ray(scene: &Scene, mut ray: Ray) -> Colour {
 
         let cos_out: f64 = ray.direction.dot(collision.normal);
 
-        let emittance = material.emittance(ray.direction * -1, cos_out);
+        match entity {
+            Entity::Light(l) => {
+                // If we hit a light on a specular bounce, just accumulate the light energy and
+                // we're done.
+                // Otherwise we've already taken lights into account via NEE, so don't
+                // accumulate.
+                if last_bounce_specular {
+                    colour += throughput * l.colour * l.intensity;
+                }
+                break;
+            },
+            Entity::Object(o) => {
+                // Next Event Estimation.
+                let direct_illumination = match scene.random_light() {
+                    Some(light) => {
+                        let point = light.random_point();
+                        let distance_to_light_squared = (point - collision.location).magnitude();
+                        let direction = (point - collision.location).normed();
+                        let shadow_ray = Ray::new(
+                            collision.location + collision.normal * 0.0001,  // Add the normal as a hack so it doesn't collide with the same object again.
+                            direction
+                        );
 
-        // Next Event Estimation.
-        let direct_illumination = match scene.random_light() {
-            Some(light) => {
-                let point = light.random_point();
-                let distance_to_light_squared = (point - collision.location).magnitude();
-                let direction = (point - collision.location).normed();
-                let shadow_ray = Ray::new(
-                    collision.location + collision.normal * 0.0001,  // Add the normal as a hack so it doesn't collide with the same object again.
-                    direction
-                );
+                        let occluded = match scene.find_intersection(shadow_ray) {
+                            Some((col, e)) => {
+                                e.id() != light.entity_id() && (col.distance * col.distance) < distance_to_light_squared
+                            },
+                            None => false,
+                        };
 
-                let occluded = match scene.find_intersection(shadow_ray) {
-                    Some((col, _)) => {
-                        (col.distance * col.distance) < distance_to_light_squared
+                        if occluded {
+                            Colour::BLACK
+                        } else {
+                            let base = light.colour * light.intensity;
+                            let brdf = o.material.brdf(ray.direction * -1, shadow_ray.direction * -1, collision.normal);
+                            let solid_angle = 1.0 / distance_to_light_squared;
+                            base * brdf * solid_angle * (collision.normal.dot(shadow_ray.direction))
+                        }
                     },
-                    None => false,
+                    None => Colour::BLACK,
                 };
 
-                if occluded {
-                    Colour::BLACK
-                } else {
-                    let base = light.colour * light.intensity;
-                    let brdf = material.brdf(ray.direction * -1, shadow_ray.direction * -1, collision.normal);
-                    let solid_angle = 1.0 / distance_to_light_squared;
-                    base * brdf * solid_angle * (collision.normal.dot(shadow_ray.direction))
+                colour += direct_illumination * throughput;
+
+                let (direction, pdf, brdf, is_specular) = o.material.sample(ray.direction * -1, collision.normal);
+                last_bounce_specular = is_specular;
+
+                // Next bounce.
+                let new_ray = Ray::new(
+                    collision.location + collision.normal * 0.0001,  // Add the normal as a hack so it doesn't collide with the same object again.
+                    direction,
+                );
+
+                let attenuation = brdf / pdf;
+                throughput = throughput * attenuation;
+
+                let emittance = o.material.emittance(ray.direction * -1, cos_out);
+                colour += emittance * throughput;
+                
+                // Chance for the material to eat the ray.
+                let survival_chance = throughput.max();
+                if rand::thread_rng().gen::<f64>() > survival_chance {
+                    break;
                 }
+
+                throughput = throughput / survival_chance;
+
+                ray = new_ray;
             },
-            None => Colour::BLACK,
         };
 
-        colour += direct_illumination * throughput;
-
-        // Next bounce.
-        let new_ray = Ray::new(
-            collision.location + collision.normal * 0.0001,  // Add the normal as a hack so it doesn't collide with the same object again.
-            material.sample_pdf(ray.direction * -1, collision.normal),
-        );
-
-        let pdf = material.weight_pdf(ray.direction * -1, new_ray.direction * -1, collision.normal);
-
-        let attenuation = material.brdf(ray.direction * -1, new_ray.direction * -1, collision.normal) / pdf;
-        throughput = throughput * attenuation;
-
-        colour += emittance * throughput;
-
-        // Chance for the material to eat the ray.
-        let survival_chance = throughput.max();
-        if rand::thread_rng().gen::<f64>() > survival_chance {
-            break;
-        }
-
-        throughput = throughput / survival_chance;
-
-        ray = new_ray;
         loops += 1;
     }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -81,8 +81,7 @@ pub fn trace_ray(scene: &Scene, mut ray: Ray) -> Colour {
                     direction,
                 );
 
-                let cos_theta = collision.normal.dot(direction);
-                let attenuation = brdf * cos_theta / pdf;
+                let attenuation = brdf / pdf;
                 throughput = throughput * attenuation;
 
                 if throughput.max() <= 0.0 {


### PR DESCRIPTION
Decided that my old implementation was basically irredeemable, so am starting mostly from scratch.

Have only implemented perfectly smooth materials so far.  But already they're looking much better than before.  And I get much more sensible results when inputting real-world parameters.

For example:

Gold
![image](https://user-images.githubusercontent.com/3620166/81149598-77cf0880-8fb9-11ea-9514-ed79f2bb94e4.png)

Green Plastic
![image](https://user-images.githubusercontent.com/3620166/81150310-a1d4fa80-8fba-11ea-9606-9247168bbd21.png)
