### PR TITLE
Fix glossy materials properly

### DIFF
--- a/src/material.rs
+++ b/src/material.rs
@@ -246,7 +246,9 @@ impl GlossMaterial {
         let r0 = self.fresnel_r0;
         let r = r0 + (1.0 - r0) * (1.0 - cos_theta).powf(5.0);
 
-        let specular_chance = r;
+        // For very reflective materials (e.g. metals) sample relative to reflectivity.
+        // For less reflective materials (e.g. plastics) sample at 0.5 to capture highlights.
+        let specular_chance = if r0 > 0.5 { r } else { 0.5 };
         let is_specular = rand::thread_rng().gen::<f64>() <= specular_chance;
 
         if is_specular {

--- a/src/material.rs
+++ b/src/material.rs
@@ -246,20 +246,21 @@ impl GlossMaterial {
         let r0 = self.fresnel_r0;
         let r = r0 + (1.0 - r0) * (1.0 - cos_theta).powf(5.0);
 
-        let is_specular = rand::thread_rng().gen::<f64>() <= r;
+        let specular_chance = r;
+        let is_specular = rand::thread_rng().gen::<f64>() <= specular_chance;
 
         if is_specular {
             let direction = self.mirror.sample_pdf(vec_out, normal);
             let vec_in = direction * -1.0;
             let pdf = self.mirror.weight_pdf(vec_out, vec_in, normal);
             let brdf = self.lambertian.albedo * self.metalness + Colour::WHITE * (1.0 - self.metalness);
-            (direction, pdf * r, brdf * r, is_specular)
+            (direction, pdf * specular_chance, brdf * r, is_specular)
         } else {
             let direction = self.lambertian.sample_pdf(vec_out, normal);
             let vec_in = direction * -1.0;
             let pdf = self.lambertian.weight_pdf(vec_out, vec_in, normal);
             let brdf = self.lambertian.brdf(vec_out, vec_in, normal) * (1.0 - self.metalness);
-            (direction, pdf * (1.0 - r), brdf * (1.0 - r), is_specular)
+            (direction, pdf * (1.0 - specular_chance), brdf * (1.0 - r), is_specular)
         }
     }
 }

--- a/src/material.rs
+++ b/src/material.rs
@@ -253,13 +253,13 @@ impl GlossMaterial {
             let vec_in = direction * -1.0;
             let pdf = self.mirror.weight_pdf(vec_out, vec_in, normal);
             let brdf = self.lambertian.albedo * self.metalness + Colour::WHITE * (1.0 - self.metalness);
-            (direction, pdf * r, brdf, is_specular)
+            (direction, pdf * r, brdf * r, is_specular)
         } else {
             let direction = self.lambertian.sample_pdf(vec_out, normal);
             let vec_in = direction * -1.0;
             let pdf = self.lambertian.weight_pdf(vec_out, vec_in, normal);
             let brdf = self.lambertian.brdf(vec_out, vec_in, normal) * (1.0 - self.metalness);
-            (direction, pdf * (1.0 - r), brdf, is_specular)
+            (direction, pdf * (1.0 - r), brdf * (1.0 - r), is_specular)
         }
     }
 }


### PR DESCRIPTION
This is the correct fix in place of the commit reverted by #32 

See now that we exactly match Mitsuba in a scene with a glossy floor (black, 0.05 reflectance)

Mine (rendered with more samples):
![image](https://user-images.githubusercontent.com/3620166/81772760-a1d87b80-9521-11ea-85af-59718edd15cc.png)

Theirs:
![image](https://user-images.githubusercontent.com/3620166/81785978-00115880-953a-11ea-9d64-de53466283ac.png)
