### PR TITLE
ModelLibrary and Vertex Colouring Support

### DIFF
--- a/scenes/doom.yml
+++ b/scenes/doom.yml
@@ -35,8 +35,10 @@ objects:
       rotation: { pitch: 0.3, yaw: 0.0, roll: 0.0 }
       scale: 1.0
     material:
-      type: Lambertian
+      type: Gloss
       albedo: { type: Vertex }
+      reflectance: 0.05
+      metalness: 0.0
 
   - shape:
       type: Sphere
@@ -44,5 +46,5 @@ objects:
       center: { x: 0.0, y: -1000140.0, z: 0.0 }
     material:
       type: Lambertian
-      albedo: { type: Static, r: 0.5, g: 0.5, b: 0.5 }
+      albedo: { type: Rgb, r: 0.5, g: 0.5, b: 0.5 }
 

--- a/scenes/doom.yml
+++ b/scenes/doom.yml
@@ -1,12 +1,12 @@
 camera:
   image_width: 720
   image_height: 480
-  location: { x: 0.0, y: 700.0, z: -700.0 }
-  orientation: { pitch: 0.8, yaw: 0.0, roll: 0.0 }
+  location: { x: 0.0, y: 500.0, z: -700.0 }
+  orientation: { pitch: 0.6, yaw: 0.0, roll: 0.0 }
   sensor_width: 0.036
   sensor_height: 0.024
   focal_length: 0.043
-  focus_distance: 15.0
+  focus_distance: 500.0
   aperture: 2.0
 
 skybox:
@@ -20,24 +20,23 @@ models:
 
 lights:
   - colour: { r: 1.0, g: 1.0, b: 1.0 }
-    intensity: 20.0
+    intensity: 60.0
     geometry:
       type: Sphere
       center: { x: 0.0, y: 500.0, z: 0.0 }
-      radius: 100.0
+      radius: 50.0
 
 objects:
   - shape:
       type: Mesh
       model: doom
+      smooth_normals: false
       translation: { x: 0.0, y: -2.2, z: 0.0 }
-      rotation: { pitch: 1.5, yaw: 0.0, roll: 0.0 }
+      rotation: { pitch: 0.3, yaw: 0.0, roll: 0.0 }
       scale: 1.0
     material:
-      type: Gloss
-      albedo: { r: 0.8, g: 0.3, b: 0.3 }
-      reflectance: 0.05
-      metalness: 0.0
+      type: Lambertian
+      albedo: { type: Vertex }
 
   - shape:
       type: Sphere
@@ -45,5 +44,5 @@ objects:
       center: { x: 0.0, y: -1000140.0, z: 0.0 }
     material:
       type: Lambertian
-      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      albedo: { type: Static, r: 0.5, g: 0.5, b: 0.5 }
 

--- a/scenes/doom.yml
+++ b/scenes/doom.yml
@@ -1,0 +1,49 @@
+camera:
+  image_width: 720
+  image_height: 480
+  location: { x: 0.0, y: 700.0, z: -700.0 }
+  orientation: { pitch: 0.8, yaw: 0.0, roll: 0.0 }
+  sensor_width: 0.036
+  sensor_height: 0.024
+  focal_length: 0.043
+  focus_distance: 15.0
+  aperture: 2.0
+
+skybox:
+  type: Gradient
+  overhead_colour: { r: 0.0, g: 0.0, b: 0.0 }
+  horizon_colour: { r: 0.0, g: 0.0, b: 0.0 }
+
+models:
+  doom:
+    file: "./assets/Doom combat scene.ply"
+
+lights:
+  - colour: { r: 1.0, g: 1.0, b: 1.0 }
+    intensity: 20.0
+    geometry:
+      type: Sphere
+      center: { x: 0.0, y: 500.0, z: 0.0 }
+      radius: 100.0
+
+objects:
+  - shape:
+      type: Mesh
+      model: doom
+      translation: { x: 0.0, y: -2.2, z: 0.0 }
+      rotation: { pitch: 1.5, yaw: 0.0, roll: 0.0 }
+      scale: 1.0
+    material:
+      type: Gloss
+      albedo: { r: 0.8, g: 0.3, b: 0.3 }
+      reflectance: 0.05
+      metalness: 0.0
+
+  - shape:
+      type: Sphere
+      radius: 1000000.0
+      center: { x: 0.0, y: -1000140.0, z: 0.0 }
+    material:
+      type: Lambertian
+      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+

--- a/scenes/dragon.yml
+++ b/scenes/dragon.yml
@@ -16,7 +16,7 @@ skybox:
 
 models:
   dragon:
-    file: "./dragon_recon/dragon_vrip.ply"
+    file: "./assets/dragon_recon/dragon_vrip.ply"
 
 lights:
   - colour: { r: 1.0, g: 1.0, b: 1.0 }
@@ -30,6 +30,7 @@ objects:
   - shape:
       type: Mesh
       model: dragon
+      smooth_normals: false
       translation: { x: 0.0, y: -2.2, z: 0.0 }
       rotation: { pitch: 3.1, yaw: 0.0, roll: 0.0 }
       scale: 40.0

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -3,8 +3,8 @@ use std::f64::consts::PI;
 use rand;
 use rand::Rng;
 
-use crate::scene::ModelLibrary;
 use crate::matrix::Matrix3;
+use crate::model::ModelLibrary;
 use crate::vector::Vector3;
 
 pub fn cosine_sample_hemisphere() -> Vector3 {
@@ -100,8 +100,11 @@ impl Mesh {
         Mesh{ model, translation, rotation, scale }
     }
 
-    pub fn primitives(&self, model_library: &ModelLibrary) -> Vec<Primitive> {
-        model_library.get(&self.model).unwrap().iter()
+    pub fn primitives(&self, model_library: &mut ModelLibrary) -> Vec<Primitive> {
+        model_library.load(&self.model);
+        model_library.get(&self.model)
+            .resolve_primitives()
+            .iter()
             .map(|t| t.transform(self.translation, self.rotation, self.scale))
             .collect()
     }

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -60,6 +60,13 @@ pub struct Collision {
     pub distance: f64,
     pub location: Vector3,
     pub normal: Vector3,
+    pub metadata: CollisionMetadata,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum CollisionMetadata {
+    None,
+    Mesh(usize, f64, f64, f64),
 }
 
 pub struct AABB {
@@ -89,7 +96,7 @@ pub enum Geometry {
 
 #[derive(Clone, Debug)]
 pub struct Mesh {
-    model: String,
+    pub model: String,
     translation: Vector3,
     rotation: Matrix3,
     scale: f64,
@@ -108,6 +115,10 @@ impl Mesh {
             .map(|t| t.transform(self.translation, self.rotation, self.scale))
             .collect()
     }
+
+    pub fn rotate(&self, v: Vector3) -> Vector3 {
+        self.rotation * v
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -121,8 +132,8 @@ impl Primitive {
         Primitive::Sphere(SpherePrimitive{ center, radius })
     }
 
-    pub fn triangle(vertices: [Vector3; 3], surface_normal: Vector3, vertex_normals: [Vector3; 3]) -> Primitive {
-        Primitive::Triangle(TrianglePrimitive{ vertices, surface_normal, vertex_normals })
+    pub fn triangle(index: usize, vertices: [Vector3; 3], surface_normal: Vector3) -> Primitive {
+        Primitive::Triangle(TrianglePrimitive{ index, vertices, surface_normal })
     }
 
     pub fn transform(&self, translation: Vector3, rotation: Matrix3, scale: f64) -> Primitive {
@@ -219,7 +230,8 @@ impl BoundedVolume for SpherePrimitive {
         let distance = if d2 > 0.0 { d2 } else { d1 };
         let location = o + (l * distance);
         let normal = (location - c).normed();
-        Some(Collision{ distance, location, normal, })
+        let metadata = CollisionMetadata::None;
+        Some(Collision{ distance, location, normal, metadata })
     }
 
     fn aabb(&self) -> AABB {
@@ -230,25 +242,21 @@ impl BoundedVolume for SpherePrimitive {
 
 #[derive(Clone, Copy, Debug)]
 pub struct TrianglePrimitive {
+    pub index: usize,
     pub vertices: [Vector3; 3],
     pub surface_normal: Vector3,
-    pub vertex_normals: [Vector3; 3],
 }
 
 impl TrianglePrimitive {
     pub fn transform(&self, translation: Vector3, rotation: Matrix3, scale: f64) -> TrianglePrimitive {
         TrianglePrimitive {
+            index: self.index,
             vertices: [
                 rotation * self.vertices[0] * scale + translation,
                 rotation * self.vertices[1] * scale + translation,
                 rotation * self.vertices[2] * scale + translation,
             ],
             surface_normal: rotation.clone() * self.surface_normal,
-            vertex_normals: [
-                rotation * self.vertex_normals[0],
-                rotation * self.vertex_normals[1],
-                rotation * self.vertex_normals[2],
-            ],
         }
     }
 }
@@ -259,9 +267,6 @@ impl BoundedVolume for TrianglePrimitive {
         let b = self.vertices[1];
         let c = self.vertices[2];
         let n = self.surface_normal;
-        let an = self.vertex_normals[0];
-        let bn = self.vertex_normals[1];
-        let cn = self.vertex_normals[2];
 
         let cos_theta = n.dot(ray.direction);
 
@@ -287,6 +292,7 @@ impl BoundedVolume for TrianglePrimitive {
         let by = area_pca / area_abc;
         let bz = 1.0 - bx - by;
 
+        /*
         let mut smooth_normal = an * bx + bn * by + cn * bz;
 
         // If the smoothed face of the triangle curves away from the ray then scale it back so it
@@ -297,13 +303,15 @@ impl BoundedVolume for TrianglePrimitive {
             let scale = (cos_alpha - epsilon) / (cos_theta + cos_alpha);
             smooth_normal = (n * scale + smooth_normal * (1.0 - scale)).normed();
         }
+        */
         
         if bx < 0.0 || by < 0.0 || bz < 0.0 {
             None
         } else {
             // Flip the normal if we're hitting the triangle from the back;
             let back_side_multiplier = if cos_theta > 0.0 { -1.0 } else { 1.0 };
-            Some(Collision{ distance: t, location: p, normal: smooth_normal * back_side_multiplier })
+            let metadata = CollisionMetadata::Mesh(self.index, bx, by, bz);
+            Some(Collision{ distance: t, location: p, normal: n * back_side_multiplier, metadata })
         }
     }
 

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -97,14 +97,15 @@ pub enum Geometry {
 #[derive(Clone, Debug)]
 pub struct Mesh {
     pub model: String,
+    pub smooth_normals: bool,
     translation: Vector3,
     rotation: Matrix3,
     scale: f64,
 }
 
 impl Mesh {
-    pub fn new(model: String, translation: Vector3, rotation: Matrix3, scale: f64) -> Mesh {
-        Mesh{ model, translation, rotation, scale }
+    pub fn new(model: String, translation: Vector3, rotation: Matrix3, scale: f64, smooth_normals: bool) -> Mesh {
+        Mesh{ model, translation, rotation, scale, smooth_normals }
     }
 
     pub fn primitives(&self, model_library: &mut ModelLibrary) -> Vec<Primitive> {
@@ -291,19 +292,6 @@ impl BoundedVolume for TrianglePrimitive {
         let bx = area_pbc / area_abc;
         let by = area_pca / area_abc;
         let bz = 1.0 - bx - by;
-
-        /*
-        let mut smooth_normal = an * bx + bn * by + cn * bz;
-
-        // If the smoothed face of the triangle curves away from the ray then scale it back so it
-        // barely doesn't.
-        if smooth_normal.dot(ray.direction) * cos_theta < 0.0 {
-            let epsilon = 0.05;  // Chosen experimentally.
-            let cos_alpha = smooth_normal.dot(ray.direction);
-            let scale = (cos_alpha - epsilon) / (cos_theta + cos_alpha);
-            smooth_normal = (n * scale + smooth_normal * (1.0 - scale)).normed();
-        }
-        */
         
         if bx < 0.0 || by < 0.0 || bz < 0.0 {
             None

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ pub mod controller;
 pub mod geom;
 pub mod material;
 pub mod matrix;
+pub mod model;
 #[macro_use] pub mod obj;
 pub mod pixels;
 pub mod ply;

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn main() {
 
     let location = camera.location;
     let orientation = camera.rot;
-    let renderer = Renderer::new(camera, Arc::new(scene), 8);
+    let renderer = Renderer::new(camera, Arc::new(scene), 4);
     let mut controller = Controller::new(renderer, location, orientation);
 
     let mut texture_buffer: Vec<u8> = vec![0; (width * height * 3) as usize];

--- a/src/model.rs
+++ b/src/model.rs
@@ -66,11 +66,11 @@ impl ModelLibrary {
 }
 
 pub struct Model {
-    vertices: Vec<Vector3>,
-    faces: Vec<(usize, usize, usize)>,
-    face_normals: Vec<Vector3>,
-    vertex_normals: Option<Vec<Vector3>>,
-    vertex_colours: Option<Vec<Colour>>,
+    pub vertices: Vec<Vector3>,
+    pub faces: Vec<(usize, usize, usize)>,
+    pub face_normals: Vec<Vector3>,
+    pub vertex_normals: Option<Vec<Vector3>>,
+    pub vertex_colours: Option<Vec<Colour>>,
 }
 
 impl Model {

--- a/src/model.rs
+++ b/src/model.rs
@@ -41,7 +41,7 @@ impl ModelLibrary {
         println!("Loading model '{}' from '{}'", name, filepath);
         let path = std::path::Path::new(&filepath);
         let extension = path.extension().map(|osstr| osstr.to_str()).flatten();
-        let mut model = match extension {
+        let model = match extension {
             Some("obj") => {
                 obj::load_obj_file(&filepath)
             },
@@ -52,13 +52,18 @@ impl ModelLibrary {
             None => panic!("Could not identify filetype for path because it has no extension: {:?}", path),
         };
 
-        model.compute_vertex_normals();
-
         self.models.insert(name.clone(), model);
     }
 
     pub fn get(&self, name: &String) -> &Model {
         match self.models.get(name) {
+            Some(m) => m,
+            None => panic!("Model '{}' has not been loaded", name),
+        }
+    }
+
+    pub fn get_mut(&mut self, name: &String) -> &mut Model {
+        match self.models.get_mut(name) {
             Some(m) => m,
             None => panic!("Model '{}' has not been loaded", name),
         }
@@ -143,6 +148,10 @@ impl Model {
     }
 
     pub fn compute_vertex_normals(&mut self) {
+        if self.vertex_normals.is_some() {
+            return;
+        }
+
         let mut vertex_normal_sums: Vec<Vector3> = vec![Vector3::new(0.0, 0.0, 0.0); self.vertices.len()];
         let mut vertex_normal_counts: Vec<usize> = vec![0; self.vertices.len()];
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,161 @@
+use std::collections::HashMap;
+
+use crate::geom::Primitive;
+use crate::obj;
+use crate::ply;
+use crate::vector::Vector3;
+
+pub struct ModelLibrary {
+    declarations: HashMap<String, ModelDeclaration>,
+    models: HashMap<String, Model>,
+}
+
+pub struct ModelDeclaration {
+    filepath: String,
+}
+
+impl ModelLibrary {
+    pub fn new() -> ModelLibrary {
+        ModelLibrary {
+            declarations: HashMap::new(),
+            models: HashMap::new(),
+        }
+    }
+
+    pub fn declare(&mut self, name: String, filepath: String) {
+        self.declarations.insert(name, ModelDeclaration{ filepath });
+    }
+
+    pub fn load(&mut self, name: &String) {
+        if self.models.contains_key(name) {
+            println!("Model '{}' already loaded.", name);
+            return;
+        }
+
+        let filepath = match self.declarations.get(name) {
+            Some(decl) => &decl.filepath,
+            None => panic!("Attempt to load model '{}' before declaration", name),
+        };
+
+        println!("Loading model '{}' from '{}'", name, filepath);
+        let path = std::path::Path::new(&filepath);
+        let extension = path.extension().map(|osstr| osstr.to_str()).flatten();
+        let model = match extension {
+            Some("obj") => {
+                obj::load_obj_file(&filepath)
+            },
+            Some("ply") => {
+                ply::load_ply_file(&filepath)
+            },
+            Some(ext) => panic!("Unknown file extension: {}", ext),
+            None => panic!("Could not identify filetype for path because it has no extension: {:?}", path),
+        };
+
+        self.models.insert(name.clone(), model);
+    }
+
+    pub fn get(&self, name: &String) -> &Model {
+        match self.models.get(name) {
+            Some(m) => m,
+            None => panic!("Model '{}' has not been loaded", name),
+        }
+    }
+}
+
+pub struct Model {
+    vertices: Vec<Vector3>,
+    faces: Vec<(usize, usize, usize)>,
+    face_normals: Vec<Vector3>,
+    vertex_normals: Option<Vec<Vector3>>,
+}
+
+impl Model {
+    pub fn new(vertices: Vec<Vector3>, faces: Vec<(usize, usize, usize)>) -> Model {
+        let face_normals = Model::compute_face_normals(&vertices, &faces);
+
+        Model { vertices, faces, face_normals, vertex_normals: None }
+    }
+
+    pub fn resolve_primitives(&self) -> Vec<Primitive> {
+        self.faces.iter()
+            .enumerate()
+            .filter_map(|(ix, &(a, b, c))| {
+                let v1 = self.vertices[a];
+                let v2 = self.vertices[b];
+                let v3 = self.vertices[c];
+
+                let vertices = [v1, v2, v3];
+                let surface_normal = self.face_normals[ix];
+
+                let vertex_normals = match self.vertex_normals {
+                    Some(ref vertex_normals) => {
+                        let vn1 = vertex_normals[a];
+                        let vn2 = vertex_normals[b];
+                        let vn3 = vertex_normals[c];
+                        [vn1, vn2, vn3]
+                    },
+                    None => [Vector3::zero(), Vector3::zero(), Vector3::zero()],
+                };
+
+                if surface_normal.is_nan() {
+                    None
+                } else {
+                    Some(Primitive::triangle(vertices, surface_normal, vertex_normals))
+                }
+            })
+            .collect()
+    }
+
+    pub fn compute_vertex_normals(&mut self) {
+        let mut vertex_normal_sums: Vec<Vector3> = vec![Vector3::new(0.0, 0.0, 0.0); self.vertices.len()];
+        let mut vertex_normal_counts: Vec<usize> = vec![0; self.vertices.len()];
+
+        self.faces.iter()
+            .enumerate()
+            .for_each(|(ix, &(a, b, c))| {
+                let n = self.face_normals[ix];
+                if n.is_nan() {
+                    return;
+                }
+
+                vertex_normal_sums[a] += n;
+                vertex_normal_sums[b] += n;
+                vertex_normal_sums[c] += n;
+                vertex_normal_counts[a] += 1;
+                vertex_normal_counts[b] += 1;
+                vertex_normal_counts[c] += 1;
+            });
+
+        self.vertex_normals = Some(
+            vertex_normal_sums.iter()
+            .enumerate()
+            .map(|(ix, &v)| v / (vertex_normal_counts[ix]) as f64)
+            .collect()
+        );
+    }
+
+    fn compute_face_normals(vertices: &Vec<Vector3>, faces: &Vec<(usize, usize, usize)>) -> Vec<Vector3> {
+        faces.iter()
+            .map(|&(a, b, c)| {
+                let v1 = vertices[a];
+                let v2 = vertices[b];
+                let v3 = vertices[c];
+                Model::face_normal(v1, v2, v3)
+            })
+            .collect()
+    }
+
+    fn face_normal(v1: Vector3, v2: Vector3, v3: Vector3) -> Vector3 {
+        let side_1 = v2 - v1;
+        let side_2 = v3 - v1;
+        let side_3 = v3 - v2;
+        let mut n = side_1.cross(side_2).normed();
+
+        if n.x.is_nan() || n.y.is_nan() || n.z.is_nan() {
+            // Try again with a different pair of sides.
+            n = side_1.cross(side_3).normed();
+        }
+
+        n
+    }
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::colour::Colour;
 use crate::geom::Primitive;
 use crate::obj;
 use crate::ply;
@@ -69,13 +70,24 @@ pub struct Model {
     faces: Vec<(usize, usize, usize)>,
     face_normals: Vec<Vector3>,
     vertex_normals: Option<Vec<Vector3>>,
+    vertex_colours: Option<Vec<Colour>>,
 }
 
 impl Model {
     pub fn new(vertices: Vec<Vector3>, faces: Vec<(usize, usize, usize)>) -> Model {
         let face_normals = Model::compute_face_normals(&vertices, &faces);
 
-        Model { vertices, faces, face_normals, vertex_normals: None }
+        Model{ 
+            vertices,
+            faces,
+            face_normals,
+            vertex_normals: None,
+            vertex_colours: None,
+        }
+    }
+
+    pub fn attach_vertex_colours(&mut self, vertex_colours: Vec<Colour>) {
+        self.vertex_colours = Some(vertex_colours);
     }
 
     pub fn smooth_normal(&self, face_ix: usize, bx: f64, by: f64, bz: f64) -> Vector3 {
@@ -91,6 +103,22 @@ impl Model {
                 smooth_normal
             },
             None => panic!("Vertex normals not pre-computed"),
+        }
+    }
+
+    pub fn smooth_colour(&self, face_ix: usize, bx: f64, by: f64, bz: f64) -> Colour {
+        match self.vertex_colours {
+            Some(ref vertex_colours) => {
+                let (a, b, c) = self.faces[face_ix];
+                let ac = vertex_colours[a];
+                let bc = vertex_colours[b];
+                let cc = vertex_colours[c];
+
+                let smooth_colour = ac * bx + bc * by + cc * bz;
+
+                smooth_colour
+            },
+            None => panic!("Model does not have vertex colours"),
         }
     }
 

--- a/src/ply.rs
+++ b/src/ply.rs
@@ -4,88 +4,8 @@ use ply_rs::parser;
 use ply_rs::ply;
 use ply_rs::ply::PropertyAccess;
 
-use crate::geom::Primitive;
+use crate::model::Model;
 use crate::vector::Vector3;
-
-pub struct Model {
-    vertices: Vec<Vector3>,
-    faces: Vec<(usize, usize, usize)>,
-}
-
-impl Model {
-    pub fn resolve_triangles(&self) -> Vec<Primitive> {
-        // Firstly, compute the face normals.
-        let face_normals: Vec<Vector3> = self.faces.iter()
-            .map(|&(a, b, c)| {
-                let v1 = self.vertices[a];
-                let v2 = self.vertices[b];
-                let v3 = self.vertices[c];
-                Model::face_normal(v1, v2, v3)
-            })
-            .collect();
-
-        let mut vertex_normal_sums: Vec<Vector3> = vec![Vector3::new(0.0, 0.0, 0.0); self.vertices.len()];
-        let mut vertex_normal_counts: Vec<usize> = vec![0; self.vertices.len()];
-
-        self.faces.iter()
-            .enumerate()
-            .for_each(|(ix, &(a, b, c))| {
-                let n = face_normals[ix];
-                if n.is_nan() {
-                    return;
-                }
-
-                vertex_normal_sums[a] += n;
-                vertex_normal_sums[b] += n;
-                vertex_normal_sums[c] += n;
-                vertex_normal_counts[a] += 1;
-                vertex_normal_counts[b] += 1;
-                vertex_normal_counts[c] += 1;
-            });
-
-        let vertex_normals: Vec<Vector3> = vertex_normal_sums.iter()
-            .enumerate()
-            .map(|(ix, &v)| v / (vertex_normal_counts[ix]) as f64)
-            .collect();
-
-        self.faces.iter()
-            .enumerate()
-            .filter_map(|(ix, &(a, b, c))| {
-                let v1 = self.vertices[a];
-                let v2 = self.vertices[b];
-                let v3 = self.vertices[c];
-
-                let vn1 = vertex_normals[a];
-                let vn2 = vertex_normals[b];
-                let vn3 = vertex_normals[c];
-
-                let vertices = [v1, v2, v3];
-                let surface_normal = face_normals[ix];
-                let vertex_normals = [vn1, vn2, vn3];
-
-                if surface_normal.is_nan() {
-                    None
-                } else {
-                    Some(Primitive::triangle(vertices, surface_normal, vertex_normals))
-                }
-            })
-            .collect()
-    }
-
-    fn face_normal(v1: Vector3, v2: Vector3, v3: Vector3) -> Vector3 {
-        let side_1 = v2 - v1;
-        let side_2 = v3 - v1;
-        let side_3 = v3 - v2;
-        let mut n = side_1.cross(side_2).normed();
-
-        if n.x.is_nan() || n.y.is_nan() || n.z.is_nan() {
-            // Try again with a different pair of sides.
-            n = side_1.cross(side_3).normed();
-        }
-
-        n
-    }
-}
 
 pub fn load_ply_file(filename: &str) -> Model {
     let mut f = File::open(filename).unwrap();
@@ -133,5 +53,5 @@ pub fn load_ply_file(filename: &str) -> Model {
     println!("Loaded {} vertices and {} faces.", vertices.len(), faces.len());
     println!("Model bounds: X: {}-{}, Y: {}-{}, Z: {}-{}", min_x, max_x, min_y, max_y, min_z, max_z);
 
-    Model{ vertices, faces }
+    Model::new(vertices, faces)
 }

--- a/src/ply.rs
+++ b/src/ply.rs
@@ -2,8 +2,9 @@ use std::fs::File;
 
 use ply_rs::parser;
 use ply_rs::ply;
-use ply_rs::ply::PropertyAccess;
+use ply_rs::ply::{PropertyAccess, ElementDef};
 
+use crate::colour::Colour;
 use crate::model::Model;
 use crate::vector::Vector3;
 
@@ -53,5 +54,25 @@ pub fn load_ply_file(filename: &str) -> Model {
     println!("Loaded {} vertices and {} faces.", vertices.len(), faces.len());
     println!("Model bounds: X: {}-{}, Y: {}-{}, Z: {}-{}", min_x, max_x, min_y, max_y, min_z, max_z);
 
-    Model::new(vertices, faces)
+    let mut model = Model::new(vertices, faces);
+
+    if has_vertex_colours(vertex) {
+        println!("Loading vertex colours...");
+
+        let vertex_colours: Vec<Colour> = ply_vertices.iter().map(|v| {
+            Colour{
+                r: v.get_uchar(&vertex.properties["red"].name).unwrap() as f64 / 255.0,
+                g: v.get_uchar(&vertex.properties["green"].name).unwrap() as f64 / 255.0,
+                b: v.get_uchar(&vertex.properties["blue"].name).unwrap() as f64 / 255.0,
+            }
+        }).collect();
+
+        model.attach_vertex_colours(vertex_colours);
+    }
+
+    model
+}
+
+fn has_vertex_colours(vertex: &ElementDef) -> bool {
+    vertex.properties.contains_key("red") && vertex.properties.contains_key("green") && vertex.properties.contains_key("blue")
 }

--- a/src/ply.rs
+++ b/src/ply.rs
@@ -101,12 +101,28 @@ pub fn load_ply_file(filename: &str) -> Model {
     let ply_vertices = &ply.payload["vertex"];
     let ply_faces = &ply.payload["face"];
 
+    let mut min_x = f64::MAX;
+    let mut min_y = f64::MAX;
+    let mut min_z = f64::MAX;
+    let mut max_x = f64::MIN;
+    let mut max_y = f64::MIN;
+    let mut max_z = f64::MIN;
+
     let vertices: Vec<Vector3> = ply_vertices.iter().map(|v| {
-        Vector3{
+        let v = Vector3{
             x: v.get_float(&vertex.properties["x"].name).unwrap() as f64,
             y: v.get_float(&vertex.properties["y"].name).unwrap() as f64,
             z: v.get_float(&vertex.properties["z"].name).unwrap() as f64,
-        }
+        };
+
+        min_x = f64::min(min_x, v.x);
+        min_y = f64::min(min_y, v.y);
+        min_z = f64::min(min_z, v.z);
+        max_x = f64::max(max_x, v.x);
+        max_y = f64::max(max_y, v.y);
+        max_z = f64::max(max_z, v.z);
+
+        v
     }).collect();
 
     let faces: Vec<(usize, usize, usize)> = ply_faces.iter().map(|f| {
@@ -115,6 +131,7 @@ pub fn load_ply_file(filename: &str) -> Model {
     }).collect();
 
     println!("Loaded {} vertices and {} faces.", vertices.len(), faces.len());
+    println!("Model bounds: X: {}-{}, Y: {}-{}, Z: {}-{}", min_x, max_x, min_y, max_y, min_z, max_z);
 
     Model{ vertices, faces }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 
 use crate::bvh::{construct_bvh_aac, BVH};
 use crate::colour::Colour;
-use crate::geom::{Collision, Geometry, Primitive, Ray};
+use crate::geom::{Collision, CollisionMetadata, Geometry, Primitive, Ray};
 use crate::material::Material;
 use crate::model::ModelLibrary;
 use crate::vector::Vector3;
@@ -102,19 +102,20 @@ pub struct GradientSky {
 
 pub struct Scene {
     pub skybox: Skybox,
+    models: ModelLibrary,
     objects: Vec<Object>,
     lights: Vec<Light>,
     bvh: BVH<EntityID>,
 }
 
 impl Scene {
-    pub fn new(mut model_library: ModelLibrary, objects: Vec<Object>, lights: Vec<Light>, skybox: Skybox) -> Scene {
+    pub fn new(mut models: ModelLibrary, objects: Vec<Object>, lights: Vec<Light>, skybox: Skybox) -> Scene {
         let object_primitives = objects.iter()
             .map(|o| {
                 let id = o.id;
                 let primitives = match o.geometry {
                     Geometry::Primitive(p) => vec![p],
-                    Geometry::Mesh(ref m) => m.primitives(&mut model_library),
+                    Geometry::Mesh(ref m) => m.primitives(&mut models),
                 };
                 primitives.into_iter().map(move|p| (p, EntityID::Object(id))).collect()
             })
@@ -134,13 +135,29 @@ impl Scene {
         let primitive_geometry = object_primitives.chain(light_primitives).collect();
 
         let bvh = construct_bvh_aac(primitive_geometry);
-        Scene { skybox, objects, lights, bvh }
+        Scene { skybox, models, objects, lights, bvh }
     }
 
     pub fn find_intersection(&self, ray: Ray) -> Option<(Collision, Entity)> {
-        self.bvh.find_intersection(ray).map(|(col, entity)| {
+        self.bvh.find_intersection(ray).map(|(mut col, entity)| {
             match entity {
-                EntityID::Object(id) => Some((col, Entity::Object(self.objects[*id].clone()))),
+                EntityID::Object(id) => {
+                    let obj = &self.objects[*id];
+                    match &obj.geometry {
+                        Geometry::Mesh(mesh) => {
+                            match col.metadata {
+                                CollisionMetadata::Mesh(face_ix, bx, by, bz) => {
+                                    let model = self.models.get(&mesh.model);
+                                    let smooth_normal = model.smooth_normal(face_ix, bx, by, bz);
+                                    col.normal = mesh.rotate(smooth_normal);
+                                    Some((col, Entity::Object(obj.clone())))
+                                },
+                                CollisionMetadata::None => panic!("Mesh collision should include metadata"),
+                            }
+                        },
+                        _ => Some((col, Entity::Object(self.objects[*id].clone()))),
+                    }
+                },
                 EntityID::Light(id) => Some((col, Entity::Light(self.lights[*id].clone()))),
             }
         }).flatten()

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -147,9 +147,11 @@ impl Scene {
                         Geometry::Mesh(mesh) => {
                             match col.metadata {
                                 CollisionMetadata::Mesh(face_ix, bx, by, bz) => {
-                                    let model = self.models.get(&mesh.model);
-                                    let smooth_normal = model.smooth_normal(face_ix, bx, by, bz);
-                                    col.normal = mesh.rotate(smooth_normal);
+                                    if mesh.smooth_normals {
+                                        let model = self.models.get(&mesh.model);
+                                        let smooth_normal = model.smooth_normal(face_ix, bx, by, bz);
+                                        col.normal = mesh.rotate(smooth_normal);
+                                    }
                                     Some((col, Entity::Object(obj.clone())))
                                 },
                                 CollisionMetadata::None => panic!("Mesh collision should include metadata"),

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -102,7 +102,7 @@ pub struct GradientSky {
 
 pub struct Scene {
     pub skybox: Skybox,
-    models: ModelLibrary,
+    pub models: ModelLibrary,
     objects: Vec<Object>,
     lights: Vec<Light>,
     bvh: BVH<EntityID>,

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use rand;
 use rand::Rng;
 
@@ -6,6 +5,7 @@ use crate::bvh::{construct_bvh_aac, BVH};
 use crate::colour::Colour;
 use crate::geom::{Collision, Geometry, Primitive, Ray};
 use crate::material::Material;
+use crate::model::ModelLibrary;
 use crate::vector::Vector3;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -63,10 +63,6 @@ pub enum LightGeometry {
     Area(Primitive),
 }
 
-pub type Model = Vec<Primitive>;
-
-pub type ModelLibrary = HashMap<String, Model>;
-
 #[derive(Clone, Copy, Debug)]
 pub enum Skybox {
     Flat(FlatSky),
@@ -112,13 +108,13 @@ pub struct Scene {
 }
 
 impl Scene {
-    pub fn new(model_library: ModelLibrary, objects: Vec<Object>, lights: Vec<Light>, skybox: Skybox) -> Scene {
+    pub fn new(mut model_library: ModelLibrary, objects: Vec<Object>, lights: Vec<Light>, skybox: Skybox) -> Scene {
         let object_primitives = objects.iter()
             .map(|o| {
                 let id = o.id;
                 let primitives = match o.geometry {
                     Geometry::Primitive(p) => vec![p],
-                    Geometry::Mesh(ref m) => m.primitives(&model_library),
+                    Geometry::Mesh(ref m) => m.primitives(&mut model_library),
                 };
                 primitives.into_iter().map(move|p| (p, EntityID::Object(id))).collect()
             })

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -6,8 +6,7 @@ use crate::matrix::Matrix3;
 use crate::vector::Vector3;
 use crate::geom;
 use crate::material::{BasicMaterial, Material};
-use crate::obj;
-use crate::ply;
+use crate::model;
 use crate::scene;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
@@ -60,34 +59,13 @@ impl SceneDescription {
     }
 
     pub fn scene(&self) -> scene::Scene {
-        let mut model_library: scene::ModelLibrary = HashMap::with_capacity(self.models.len());
+        let mut model_library = model::ModelLibrary::new();
         let mut objects: Vec<scene::Object> = Vec::with_capacity(self.objects.len());
         let mut lights: Vec<scene::Light> = Vec::with_capacity(self.lights.len());
 
         self.models.iter().for_each(|(name, desc)| {
-            println!("Loading model '{}' from '{}'", name, desc.file);
-            let path = std::path::Path::new(&desc.file);
-            let extension = path.extension().map(|osstr| osstr.to_str()).flatten();
-            let model = match extension {
-                Some("obj") => {
-                    obj::load_obj_file(&desc.file)
-                        .resolve_triangles()
-                        .iter()
-                        .map(|v| *v)
-                        .collect()
-                },
-                Some("ply") => {
-                    ply::load_ply_file(&desc.file)
-                        .resolve_triangles()
-                        .iter()
-                        .map(|v| *v)
-                        .collect()
-                },
-                Some(ext) => panic!("Unknown file extension: {}", ext),
-                None => panic!("Could not identify filetype for path because it has no extension: {:?}", path),
-            };
-
-            model_library.insert(name.clone(), model);
+            println!("Declaring model '{}' from '{}'", name, desc.file);
+            model_library.declare(name.clone(), desc.file.clone());
         });
 
         self.objects.iter().enumerate().for_each(|(ix, o)| {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -79,7 +79,7 @@ impl SceneDescription {
                     let translation = shp.translation.to_vector();
                     let rotation = Matrix3::rotation(shp.rotation.pitch, shp.rotation.yaw, shp.rotation.roll);
                     geom::Geometry::Mesh(
-                        geom::Mesh::new(shp.model.clone(), translation, rotation, shp.scale)
+                        geom::Mesh::new(shp.model.clone(), translation, rotation, shp.scale, shp.smooth_normals)
                     )
                 },
             };
@@ -189,9 +189,16 @@ pub struct SphereDescription {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MeshDescription {
     pub model: String,
+
+    #[serde(default = "default_smooth_normals")]
+    pub smooth_normals: bool,
     pub translation: VectorDescription,
     pub rotation: RotationDescription,
     pub scale: f64,
+}
+
+fn default_smooth_normals() -> bool {
+    true
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -38,14 +38,14 @@ impl ColourDescription {
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum MaterialColourDescription {
-    Static { r: f64, g: f64, b: f64 },
+    Rgb { r: f64, g: f64, b: f64 },
     Vertex,
 }
 
 impl MaterialColourDescription {
     pub fn to_material_colour(&self) -> MaterialColour {
         match self {
-            MaterialColourDescription::Static { r, g, b } => MaterialColour::Static(Colour::rgb(*r, *g, *b)),
+            MaterialColourDescription::Rgb { r, g, b } => MaterialColour::Static(Colour::rgb(*r, *g, *b)),
             MaterialColourDescription::Vertex => MaterialColour::Vertex,
         }
     }
@@ -242,7 +242,7 @@ impl From<&MaterialDescription> for Material {
             MaterialDescription::Lambertian(mat) => Material::lambertian(
                 mat.albedo.to_material_colour(), Colour::BLACK
             ),
-            MaterialDescription::Gloss(mat) => Material::gloss(mat.albedo.to_colour(), mat.reflectance, mat.metalness),
+            MaterialDescription::Gloss(mat) => Material::gloss(mat.albedo.to_material_colour(), mat.reflectance, mat.metalness),
             MaterialDescription::Mirror(_mat) => Material::mirror(),
             MaterialDescription::CookTorrance(mat) => Material::cook_torrance(mat.albedo.to_colour(), mat.roughness),
             MaterialDescription::Fresnel(mat) => 
@@ -261,7 +261,7 @@ impl From<BasicMaterialDescription> for BasicMaterial {
             BasicMaterialDescription::Lambertian(mat) => Material::lambertian(
                 mat.albedo.to_material_colour(), Colour::BLACK
             ).to_basic(),
-            BasicMaterialDescription::Gloss(mat) => Material::gloss(mat.albedo.to_colour(), mat.reflectance, mat.metalness).to_basic(),
+            BasicMaterialDescription::Gloss(mat) => Material::gloss(mat.albedo.to_material_colour(), mat.reflectance, mat.metalness).to_basic(),
             BasicMaterialDescription::Mirror(_mat) => Material::mirror().to_basic(),
             BasicMaterialDescription::CookTorrance(mat) => Material::cook_torrance(mat.albedo.to_colour(), mat.roughness).to_basic(),
         }
@@ -275,7 +275,7 @@ pub struct LambertianMaterialDescription {
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct GlossMaterialDescription {
-    pub albedo: ColourDescription,
+    pub albedo: MaterialColourDescription,
     pub reflectance: f64,
     pub metalness: f64,
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -94,6 +94,14 @@ impl SceneDescription {
                     println!("Constructing object using model '{}'", shp.model);
                     let translation = shp.translation.to_vector();
                     let rotation = Matrix3::rotation(shp.rotation.pitch, shp.rotation.yaw, shp.rotation.roll);
+
+                    if shp.smooth_normals {
+                        // Ensure vertex normals are pre-calculated if we want smooth normals.
+                        model_library
+                            .get_mut(&shp.model)
+                            .compute_vertex_normals();
+                    }
+
                     geom::Geometry::Mesh(
                         geom::Mesh::new(shp.model.clone(), translation, rotation, shp.scale, shp.smooth_normals)
                     )

--- a/src/stress.rs
+++ b/src/stress.rs
@@ -43,14 +43,15 @@ fn random_sphere() -> serde::ShapeDescription {
 fn random_material() -> serde::MaterialDescription {
     let mut rng = rand::thread_rng();
     let choice = rng.gen_range(0, 3);
+    let colour = random_colour();
     match choice {
         0 => serde::MaterialDescription::Gloss(serde::GlossMaterialDescription{
-            albedo: random_colour(),
+            albedo: colour,
             reflectance: 1.0 + rng.gen::<f64>() * 2.0,
             metalness: 0.0,
         }),
         1 => serde::MaterialDescription::Lambertian(serde::LambertianMaterialDescription{
-            albedo: random_colour(),
+            albedo: serde::MaterialColourDescription::Static { r: colour.r, g: colour.g, b: colour.b },
         }),
         _ => serde::MaterialDescription::Mirror(serde::MirrorMaterialDescription{}),
     }

--- a/src/stress.rs
+++ b/src/stress.rs
@@ -46,12 +46,12 @@ fn random_material() -> serde::MaterialDescription {
     let colour = random_colour();
     match choice {
         0 => serde::MaterialDescription::Gloss(serde::GlossMaterialDescription{
-            albedo: colour,
+            albedo: serde::MaterialColourDescription::Rgb { r: colour.r, g: colour.g, b: colour.b },
             reflectance: 1.0 + rng.gen::<f64>() * 2.0,
             metalness: 0.0,
         }),
         1 => serde::MaterialDescription::Lambertian(serde::LambertianMaterialDescription{
-            albedo: serde::MaterialColourDescription::Static { r: colour.r, g: colour.g, b: colour.b },
+            albedo: serde::MaterialColourDescription::Rgb { r: colour.r, g: colour.g, b: colour.b },
         }),
         _ => serde::MaterialDescription::Mirror(serde::MirrorMaterialDescription{}),
     }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -12,6 +12,10 @@ impl Vector3 {
         Vector3 { x, y, z }
     }
 
+    pub fn zero() -> Vector3 {
+        Vector3::new(0.0, 0.0, 0.0)
+    }
+
     pub fn is_nan(&self) -> bool {
         self.x.is_nan() || self.y.is_nan() || self.z.is_nan()
     }


### PR DESCRIPTION
Model handling logic extracted into ModelLibrary object.

Added support for vertex colours baked into models.
This should get us most of the way to supporting textures as well.

Example (3 minutes, ~100spp, 3.2mil triangles) (model from [Artec3D](https://www.artec3d.com/3d-models/doom-combat-scene)):
![image](https://user-images.githubusercontent.com/3620166/81828266-92cee900-9574-11ea-8d76-28f2874c82e8.png)

