### PR TITLE
Use tobj library to parse obj files.  Fix out of date scene files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tobj 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -608,6 +609,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "tobj"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +747,7 @@ dependencies = [
 "checksum syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum threadpool 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e8dae184447c15d5a6916d973c642aec485105a13cd238192a6927ae3e077d66"
+"checksum tobj 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "42748fb67ae45bff1caad8ff18de46f85347b8e14caf2a29fa6b12d741e15fdb"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,11 @@ nom = "^4.2"
 ply-rs = "^0.1.2"
 rand = "^0.6.5"
 sdl2 = { version = "0.31", features = ["unsafe_textures"] }
-threadpool = "^1.7.1"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_yaml = "^0.8"
+threadpool = "^1.7.1"
+tobj = "^2.0.0"
 
 [profile.dev]
 opt-level = 3

--- a/scenes/bunny.yml
+++ b/scenes/bunny.yml
@@ -37,7 +37,7 @@ objects:
       scale: 20.0
     material:
       type: Gloss
-      albedo: { r: 0.8, g: 0.3, b: 0.3 }
+      albedo: { type: Rgb, r: 0.8, g: 0.3, b: 0.3 }
       reflectance: 0.8
       metalness: 1.0
 
@@ -47,7 +47,7 @@ objects:
       center: { x: 3.0, y: 1.0, z: 3.0 }
     material:
       type: Gloss
-      albedo: { r: 0.3, g: 0.3, b: 0.8 }
+      albedo: { type: Rgb, r: 0.3, g: 0.3, b: 0.8 }
       reflectance: 0.04
       metalness: 0.0
 
@@ -57,7 +57,7 @@ objects:
       center: { x: 0.0, y: -1000000.0, z: 0.0 }
     material:
       type: Gloss
-      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      albedo: { type: Rgb, r: 0.5, g: 0.5, b: 0.5 }
       reflectance: 0.04
       metalness: 0.0
 
@@ -67,7 +67,7 @@ objects:
       center: { x: 0.0, y: 0.0, z: 1000010.0 }
     material:
       type: Gloss
-      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      albedo: { type: Rgb, r: 0.5, g: 0.5, b: 0.5 }
       reflectance: 0.04
       metalness: 0.0
 

--- a/scenes/dragon.yml
+++ b/scenes/dragon.yml
@@ -36,7 +36,7 @@ objects:
       scale: 40.0
     material:
       type: Gloss
-      albedo: { r: 0.92, g: 0.78, b: 0.40 }
+      albedo: { type: Rgb, r: 0.92, g: 0.78, b: 0.40 }
       reflectance: 1.0
       metalness: 1.0
 
@@ -46,7 +46,7 @@ objects:
       center: { x: 0.0, y: -1000000.0, z: 0.0 }
     material:
       type: Lambertian
-      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      albedo: { type: Rgb, r: 0.5, g: 0.5, b: 0.5 }
 
   - shape:
       type: Sphere
@@ -54,7 +54,7 @@ objects:
       center: { x: 0.0, y: 1000020.0, z: 0.0 }
     material:
       type: Lambertian
-      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      albedo: { type: Rgb, r: 0.5, g: 0.5, b: 0.5 }
 
   - shape:
       type: Sphere
@@ -62,7 +62,7 @@ objects:
       center: { x: 0.0, y: 0.0, z: 1000010.0 }
     material:
       type: Lambertian
-      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      albedo: { type: Rgb, r: 0.5, g: 0.5, b: 0.5 }
 
   - shape:
       type: Sphere
@@ -70,7 +70,7 @@ objects:
       center: { x: 0.0, y: 0.0, z: -1000020.0 }
     material:
       type: Lambertian
-      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      albedo: { type: Rgb, r: 0.5, g: 0.5, b: 0.5 }
 
   - shape:
       type: Sphere
@@ -78,7 +78,7 @@ objects:
       center: { x: -1000010.0, y: 0.0, z: 0.0 }
     material:
       type: Lambertian
-      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      albedo: { type: Rgb, r: 0.5, g: 0.5, b: 0.5 }
 
   - shape:
       type: Sphere
@@ -86,4 +86,4 @@ objects:
       center: { x: 1000010.0, y: 0.0, z: 0.0 }
     material:
       type: Lambertian
-      albedo: { r: 0.5, g: 0.5, b: 0.5 }
+      albedo: { type: Rgb, r: 0.5, g: 0.5, b: 0.5 }

--- a/scenes/teapot.yml
+++ b/scenes/teapot.yml
@@ -28,30 +28,20 @@ objects:
       rotation: { pitch: 0.4, yaw: 0.0, roll: 0.0 }
       scale: 1.0
     material:
-      type: Fresnel
-      refractive_index: 1.5
-      diffuse:
-        type: Lambertian
-        albedo: { r: 0.8, g: 0.3, b: 0.3 }
-      specular: 
-        type: CookTorrance
-        albedo: { r: 1.0, g: 1.0, b: 1.0 }
-        roughness: 0.1
+      type: Gloss
+      albedo: { type: Rgb, r: 0.8, g: 0.3, b: 0.3 }
+      reflectance: 0.05
+      metalness: 0.0
 
   - shape:
       type: Sphere
       radius: 1.0
       center: { x: 3.0, y: 1.0, z: 0.0 }
     material:
-      type: Fresnel
-      refractive_index: 2.5
-      diffuse:
-        type: Lambertian
-        albedo: { r: 0.5, g: 0.5, b: 0.8 }
-      specular: 
-        type: CookTorrance
-        albedo: { r: 1.0, g: 1.0, b: 1.0 }
-        roughness: 0.01
+      type: Gloss
+      albedo: { type: Rgb, r: 0.5, g: 0.5, b: 0.8 }
+      reflectance: 0.05
+      metalness: 0.0
 
   - shape:
       type: Sphere
@@ -59,5 +49,6 @@ objects:
       center: { x: 0.0, y: -1000000.0, z: 0.0 }
     material:
       type: Gloss
-      albedo: { r: 0.8, g: 0.8, b: 0.8 }
-      reflectance: 2.5
+      albedo: { type: Rgb, r: 0.8, g: 0.8, b: 0.8 }
+      reflectance: 0.05
+      metalness: 0.0

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -109,7 +109,6 @@ impl Mesh {
     }
 
     pub fn primitives(&self, model_library: &mut ModelLibrary) -> Vec<Primitive> {
-        model_library.load(&self.model);
         model_library.get(&self.model)
             .resolve_primitives()
             .iter()

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -1,146 +1,31 @@
-use std::fs::File;
-use std::io::{Read};
-use std::str::FromStr;
-
-use nom::{digit, double};
-use nom::types::CompleteStr;
+use tobj;
 
 use crate::model::Model;
 use crate::vector::Vector3;
 
 pub fn load_obj_file(filename: &str) -> Model {
-    let f = File::open(filename).unwrap();
-    parse_obj(f)
+    let (models, _materials) = tobj::load_obj(filename, true).expect("Failed to load obj file");
+    if models.len() > 1 {
+        panic!("Obj file '{}' contains more than 1 model.  This is unsupported.", filename);
+    }
+
+    let model = &models[0];
+
+    convert_model(model)
 }
 
-// This is a MASSIVE over-simplification of the .obj file format and won't work
-// for any but the simplest possible files.
-pub fn parse_obj<R>(mut reader: R) -> Model where R : Read {
-    let mut contents = Vec::new();
-    reader.read_to_end(&mut contents).unwrap();
+pub fn convert_model(obj_model: &tobj::Model) -> Model {
+    let vertices: Vec<Vector3> = obj_model.mesh.positions
+        .chunks_exact(3)
+        .map(|coords| {
+            Vector3::new(coords[0] as f64, coords[1] as f64, coords[2] as f64)
+        }).collect();
 
-    let contents_str = std::str::from_utf8(contents.as_slice()).unwrap();
-    let input = CompleteStr(contents_str);
-    object(input).unwrap().1
-}
+    let faces: Vec<(usize, usize, usize)> = obj_model.mesh.indices
+        .chunks_exact(3)
+        .map(|indices| {
+            (indices[0] as usize, indices[1] as usize, indices[2] as usize)
+        }).collect();
 
-named!(newline(CompleteStr) -> (),
-    do_parse!(opt!(char!('\r')) >> char!('\n') >> ())
-);
-
-named!(index(CompleteStr) -> usize, map_res!(recognize!(digit), |c: CompleteStr| usize::from_str(*c)));
-
-named!(float(CompleteStr) -> f64, call!(double));
-
-named!(vertex(CompleteStr) -> Vector3,
-    do_parse!(
-           char!('v') >>
-           char!(' ') >>
-        x: float      >>
-           char!(' ') >>
-        y: float      >>
-           char!(' ') >>
-        z: float      >>
-        (Vector3::new(x, y, z))
-    )
-);
-
-named!(face(CompleteStr) -> (usize, usize, usize),
-    do_parse!(
-           char!('f') >>
-           char!(' ') >>
-        a: index      >>
-           char!(' ') >>
-        b: index      >>
-           char!(' ') >>
-        c: index      >>
-        (a - 1, b - 1, c - 1)  // These are 1-indexed in the file.
-    )
-);
-
-named!(vertices(CompleteStr) -> Vec<Vector3>, many1!(terminated!(vertex, opt!(newline))));
-
-named!(faces(CompleteStr) -> Vec<(usize, usize, usize)>, many1!(terminated!(face, opt!(newline))));
-
-named!(object(CompleteStr) -> Model,
-    do_parse!(
-        vertices: vertices            >>
-                  many0!(char!('\n')) >>
-        faces:    faces               >>
-        (Model::new(vertices, faces))
-    )
-);
-
-#[cfg(test)]
-mod test {
-    use std::fs::File;
-    use std::path::PathBuf;
-
-    use super::*;
-
-    #[test]
-    fn test_vertex() {
-        assert_eq!(
-            vertex(CompleteStr("v 0.1 1.5 27")),
-            Ok((CompleteStr(""), Vector3::new(0.1, 1.5, 27.0))));
-    }
-
-    #[test]
-    fn test_face() {
-        assert_eq!(
-            face(CompleteStr("f 43 1 562")),
-            Ok((CompleteStr(""), (42, 0, 561))));
-    }
-
-    #[test]
-    fn test_vertices() {
-        assert_eq!(
-            vertices(CompleteStr("v 1 2 3\nv 4 5 6\nv 7 8 9\n")),
-            Ok((CompleteStr(""), vec![
-               Vector3::new(1.0, 2.0, 3.0),
-               Vector3::new(4.0, 5.0, 6.0),
-               Vector3::new(7.0, 8.0, 9.0),
-            ])));
-    }
-
-    #[test]
-    fn test_faces() {
-        assert_eq!(
-            faces(CompleteStr("f 1 2 3\nf 4 5 6\nf 7 8 9\n")),
-            Ok((CompleteStr(""), vec![
-               (0, 1, 2),
-               (3, 4, 5),
-               (6, 7, 8),
-            ])));
-    }
-
-    #[test]
-    fn test_teapot() {
-        let teapot = parse_obj_file("scenes/objects/teapot.obj");
-        assert_eq!(teapot.vertices.len(), 3644);
-        assert_eq!(teapot.vertices[0], Vector3::new(-3.0, 1.8, 0.0));
-        assert_eq!(teapot.vertices[3643], Vector3::new(3.434, 2.4729, 0.0));
-
-        assert_eq!(teapot.faces.len(), 6320);
-        assert_eq!(teapot.faces[0], (2908, 2920, 2938));
-        assert_eq!(teapot.faces[6319], (3000, 3003, 3021));
-    }
-
-    fn parse_obj_file(name: &str) -> Model {
-        let mut f = File::open(test_resource_path(name)).unwrap();
-        let mut contents = Vec::new();
-        f.read_to_end(&mut contents).unwrap();
-
-        let contents_str = std::str::from_utf8(contents.as_slice()).unwrap();
-        let input = CompleteStr(contents_str);
-        let res = object(input).unwrap();
-        assert_eq!(res.0, CompleteStr(""));
-        res.1
-    }
-
-    fn test_resource_path(name: &str) -> PathBuf {
-        let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        buf.push(name);
-        buf
-    }
+    Model::new(vertices, faces)
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -95,6 +95,9 @@ impl SceneDescription {
                     let translation = shp.translation.to_vector();
                     let rotation = Matrix3::rotation(shp.rotation.pitch, shp.rotation.yaw, shp.rotation.roll);
 
+                    // Ensure model is loaded.
+                    model_library.load(&shp.model);
+
                     if shp.smooth_normals {
                         // Ensure vertex normals are pre-calculated if we want smooth normals.
                         model_library


### PR DESCRIPTION
This lets us delete all the gross manual parsing code we had for obj files.

Also since tobj supports all properties of obj files, we can much more easily add support for more features going forward.