### PR TITLE
Support obj files with multiple models inside

### DIFF
--- a/scenes/iron-man.yml
+++ b/scenes/iron-man.yml
@@ -1,0 +1,47 @@
+camera:
+  image_width: 720
+  image_height: 480
+  location: { x: 0.0, y: 300.0, z: -500.0 }
+  orientation: { pitch: 0.3, yaw: 0.0, roll: 0.0 }
+  sensor_width: 0.036
+  sensor_height: 0.024
+  focal_length: 0.043
+  focus_distance: 300.0
+  aperture: 2.0
+
+skybox:
+  type: Gradient
+  overhead_colour: { r: 0.0, g: 0.0, b: 0.0 }
+  horizon_colour: { r: 0.0, g: 0.0, b: 0.0 }
+
+models:
+  doom:
+    file: "./assets/IronMan/IronMan.obj"
+
+lights:
+  - colour: { r: 1.0, g: 1.0, b: 1.0 }
+    intensity: 60.0
+    geometry:
+      type: Sphere
+      center: { x: 0.0, y: 500.0, z: 0.0 }
+      radius: 50.0
+
+objects:
+  - shape:
+      type: Mesh
+      model: doom
+      smooth_normals: true
+      translation: { x: 0.0, y: -2.2, z: 0.0 }
+      rotation: { pitch: 3.0, yaw: 0.0, roll: 0.0 }
+      scale: 1.0
+    material:
+      type: Auto
+
+  - shape:
+      type: Sphere
+      radius: 1000000.0
+      center: { x: 0.0, y: -1000140.0, z: 0.0 }
+    material:
+      type: Lambertian
+      albedo: { type: Rgb, r: 0.5, g: 0.5, b: 0.5 }
+

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -96,7 +96,7 @@ pub enum Geometry {
 
 #[derive(Clone, Debug)]
 pub struct Mesh {
-    pub model: String,
+    pub model: usize,
     pub smooth_normals: bool,
     translation: Vector3,
     rotation: Matrix3,
@@ -104,12 +104,12 @@ pub struct Mesh {
 }
 
 impl Mesh {
-    pub fn new(model: String, translation: Vector3, rotation: Matrix3, scale: f64, smooth_normals: bool) -> Mesh {
+    pub fn new(model: usize, translation: Vector3, rotation: Matrix3, scale: f64, smooth_normals: bool) -> Mesh {
         Mesh{ model, translation, rotation, scale, smooth_normals }
     }
 
     pub fn primitives(&self, model_library: &mut ModelLibrary) -> Vec<Primitive> {
-        model_library.get(&self.model)
+        model_library.get(self.model)
             .resolve_primitives()
             .iter()
             .map(|t| t.transform(self.translation, self.rotation, self.scale))

--- a/src/model.rs
+++ b/src/model.rs
@@ -76,6 +76,7 @@ pub struct Model {
     pub face_normals: Vec<Vector3>,
     pub vertex_normals: Option<Vec<Vector3>>,
     pub vertex_colours: Option<Vec<Colour>>,
+    pub texture_coords: Option<Vec<(f64, f64)>>,
 }
 
 impl Model {
@@ -88,11 +89,16 @@ impl Model {
             face_normals,
             vertex_normals: None,
             vertex_colours: None,
+            texture_coords: None,
         }
     }
 
     pub fn attach_vertex_colours(&mut self, vertex_colours: Vec<Colour>) {
         self.vertex_colours = Some(vertex_colours);
+    }
+
+    pub fn attach_texture_coords(&mut self, texture_coords: Vec<(f64, f64)>) {
+        self.texture_coords = Some(texture_coords);
     }
 
     pub fn smooth_normal(&self, face_ix: usize, bx: f64, by: f64, bz: f64) -> Vector3 {

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,71 +2,103 @@ use std::collections::HashMap;
 
 use crate::colour::Colour;
 use crate::geom::Primitive;
+use crate::material::Material;
 use crate::obj;
 use crate::ply;
 use crate::vector::Vector3;
 
 pub struct ModelLibrary {
     declarations: HashMap<String, ModelDeclaration>,
-    models: HashMap<String, Model>,
+    models: Vec<Model>,
 }
 
+#[derive(Clone, Debug)]
 pub struct ModelDeclaration {
     filepath: String,
+    is_loaded: bool,
+    loaded_models: Vec<usize>,
+}
+
+impl ModelDeclaration {
+    pub fn new(filepath: String) -> ModelDeclaration {
+        ModelDeclaration {
+            filepath,
+            is_loaded: false,
+            loaded_models: Vec::new(),
+        }
+    }
+
+    pub fn mark_loaded(&mut self, models: Vec<usize>) {
+        self.loaded_models = models;
+        self.is_loaded = true;
+    }
 }
 
 impl ModelLibrary {
     pub fn new() -> ModelLibrary {
         ModelLibrary {
             declarations: HashMap::new(),
-            models: HashMap::new(),
+            models: Vec::new(),
         }
     }
 
     pub fn declare(&mut self, name: String, filepath: String) {
-        self.declarations.insert(name, ModelDeclaration{ filepath });
+        self.declarations.insert(name, ModelDeclaration::new(filepath));
     }
 
-    pub fn load(&mut self, name: &String) {
-        if self.models.contains_key(name) {
-            println!("Model '{}' already loaded.", name);
-            return;
-        }
-
-        let filepath = match self.declarations.get(name) {
-            Some(decl) => &decl.filepath,
+    pub fn load(&mut self, name: &String) -> Vec<usize> {
+        let mut decl = match self.declarations.get(name) {
+            Some(decl) => decl.clone(),
             None => panic!("Attempt to load model '{}' before declaration", name),
         };
+
+        if decl.is_loaded {
+            println!("Model '{}' already loaded.", name);
+            return decl.loaded_models.clone();
+        }
+
+        let filepath = &decl.filepath;
 
         println!("Loading model '{}' from '{}'", name, filepath);
         let path = std::path::Path::new(&filepath);
         let extension = path.extension().map(|osstr| osstr.to_str()).flatten();
-        let model = match extension {
+
+        let base_ix = self.models.len();
+        let model_indices = match extension {
             Some("obj") => {
-                obj::load_obj_file(&filepath)
+                let model_indices = obj::load_obj_file(&filepath)
+                    .drain(..)
+                    .enumerate()
+                    .map(|(ix, m)| {
+                        self.models.push(m);
+                        base_ix + ix
+                    })
+                    .collect();
+
+                model_indices
             },
             Some("ply") => {
-                ply::load_ply_file(&filepath)
+                let model = ply::load_ply_file(&filepath);
+                let ix = self.models.len();
+                self.models.push(model);
+                vec![ix]
             },
             Some(ext) => panic!("Unknown file extension: {}", ext),
             None => panic!("Could not identify filetype for path because it has no extension: {:?}", path),
         };
 
-        self.models.insert(name.clone(), model);
+        decl.mark_loaded(model_indices.clone());
+        self.declarations.insert(name.clone(), decl);
+
+        model_indices
     }
 
-    pub fn get(&self, name: &String) -> &Model {
-        match self.models.get(name) {
-            Some(m) => m,
-            None => panic!("Model '{}' has not been loaded", name),
-        }
+    pub fn get(&self, ix: usize) -> &Model {
+        &self.models[ix]
     }
 
-    pub fn get_mut(&mut self, name: &String) -> &mut Model {
-        match self.models.get_mut(name) {
-            Some(m) => m,
-            None => panic!("Model '{}' has not been loaded", name),
-        }
+    pub fn get_mut(&mut self, ix: usize) -> &mut Model {
+        &mut self.models[ix]
     }
 }
 
@@ -77,6 +109,7 @@ pub struct Model {
     pub vertex_normals: Option<Vec<Vector3>>,
     pub vertex_colours: Option<Vec<Colour>>,
     pub texture_coords: Option<Vec<(f64, f64)>>,
+    pub material: Option<Material>,
 }
 
 impl Model {
@@ -90,6 +123,7 @@ impl Model {
             vertex_normals: None,
             vertex_colours: None,
             texture_coords: None,
+            material: None,
         }
     }
 
@@ -99,6 +133,10 @@ impl Model {
 
     pub fn attach_texture_coords(&mut self, texture_coords: Vec<(f64, f64)>) {
         self.texture_coords = Some(texture_coords);
+    }
+
+    pub fn attach_material(&mut self, material: Material) {
+        self.material = Some(material);
     }
 
     pub fn smooth_normal(&self, face_ix: usize, bx: f64, by: f64, bz: f64) -> Vector3 {

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -12,7 +12,11 @@ pub fn load_obj_file(filename: &str) -> Vec<Model> {
         .map(|m| convert_material(m))
         .collect();
 
-    let models = obj_models.iter().map(|m| convert_model(m, &materials)).collect();
+    println!("Loaded {} materials", materials.len());
+
+    let models: Vec<Model> = obj_models.iter().map(|m| convert_model(m, &materials)).collect();
+
+    println!("Loaded {} models", models.len());
 
     models
 }
@@ -35,10 +39,13 @@ fn convert_model(obj_model: &tobj::Model, materials: &Vec<Material>) -> Model {
             (indices[0] as usize, indices[1] as usize, indices[2] as usize)
         }).collect();
 
+    println!("Loaded model with {} vertices and {} faces", vertices.len(), faces.len());
+
     let mut model = Model::new(vertices, faces);
 
     let texcoords = &obj_model.mesh.texcoords;
     if texcoords.len() > 0 {
+        println!("Model has texture coordinates");
         let texture_coords = texcoords
             .chunks_exact(2)
             .map(|coords| {
@@ -50,6 +57,7 @@ fn convert_model(obj_model: &tobj::Model, materials: &Vec<Material>) -> Model {
 
     match obj_model.mesh.material_id {
         Some(mat) => {
+            println!("Model has associated material");
             model.attach_material(materials[mat]);
         },
         None => (),

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -27,5 +27,18 @@ pub fn convert_model(obj_model: &tobj::Model) -> Model {
             (indices[0] as usize, indices[1] as usize, indices[2] as usize)
         }).collect();
 
-    Model::new(vertices, faces)
+    let mut model = Model::new(vertices, faces);
+
+    let texcoords = &obj_model.mesh.texcoords;
+    if texcoords.len() > 0 {
+        let texture_coords = texcoords
+            .chunks_exact(2)
+            .map(|coords| {
+                (coords[0] as f64, coords[1] as f64)
+            }).collect();
+
+        model.attach_texture_coords(texture_coords);
+    }
+
+    model
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -148,7 +148,7 @@ impl Scene {
                             match col.metadata {
                                 CollisionMetadata::Mesh(face_ix, bx, by, bz) => {
                                     if mesh.smooth_normals {
-                                        let model = self.models.get(&mesh.model);
+                                        let model = self.models.get(mesh.model);
                                         let smooth_normal = model.smooth_normal(face_ix, bx, by, bz);
                                         col.normal = mesh.rotate(smooth_normal);
                                     }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -43,7 +43,7 @@ pub fn trace_ray(scene: &Scene, mut ray: Ray) -> Colour {
                 // Resolve material at point.
                 let material = match o.geometry {
                     Geometry::Mesh(mesh) => {
-                        let model = scene.models.get(&mesh.model);
+                        let model = scene.models.get(mesh.model);
                         o.material.resolve(&collision, model)
                     },
                     _ => o.material,


### PR DESCRIPTION
Right now we just splat these out into separate internal models so we don't need to change our assumptions that each "model" has exactly one material.